### PR TITLE
added can support for x28 modules like the wp76xx

### DIFF
--- a/linux_kernel_modules/can_common/start_can _x28.sh
+++ b/linux_kernel_modules/can_common/start_can _x28.sh
@@ -1,0 +1,22 @@
+# It seems that taking the IoT card out of reset fails in the core
+# mangOH driver - but placing things after user-space has fully started
+# and through the SWI gpiolib-sysfs code works - TODO fix and move into
+# the core driver so no shell script is needed.
+# Thus, we remove the inserted chip driver and bring it back.
+
+drv_file=`find /legato/systems/current/modules/ -name "*mcp251x.ko"`
+drv=`basename $drv_file`
+# remove the driver
+rmmod $drv
+
+echo 7 > /sys/class/gpio/export
+echo out  > /sys/class/gpio/gpio7/direction
+echo 1  > /sys/class/gpio/gpio7/value
+
+mux 5
+mux 16
+
+# Bring driver back & iproute2 add in CAN
+insmod $drv_file
+ip link set can0 type can bitrate 125000 triple-sampling on
+ifconfig can0 up

--- a/mangOH.sdef
+++ b/mangOH.sdef
@@ -160,6 +160,9 @@ kernelModules:
      */
     $CURDIR/linux_kernel_modules/lsm6ds3/lsm6ds3-i2c
     $CURDIR/linux_kernel_modules/lsm6ds3/lsm6ds3
+	
+	// Uncomment to build for the CAN Bus IoT card on mangOH Red
+    // #include "sinc/mangoh_green_can_iot_card.sinc"
 #elif ${MANGOH_BOARD} = yellow
     $CURDIR/linux_kernel_modules/mangoh/mangoh_yellow_dev
 #if ${MANGOH_KERNEL_LACKS_IIO} = 1

--- a/sinc/mangoh_green_can_iot_card.sinc
+++ b/sinc/mangoh_green_can_iot_card.sinc
@@ -1,0 +1,24 @@
+/*
+ * CAN Bus IoT card kernel modules for mangOH Red
+ *
+ * Directions: Include this .sinc file within the kernelModules section of the SDEF.
+ *
+ * wp85/75 kernels don't include any CAN bus in the Kernel config - thus, all the modules are out of
+ * tree.
+ *
+ * wp76/77 kernels include the CAN bus in the Kernel config as a built-in module, but not the chip
+ * driver. Thus, only the chip driver is out of tree for wp76/77 kernels.
+ */
+    $CURDIR/../linux_kernel_modules/can_common/can_iot
+#if ${MANGOH_WP_CHIPSET_9X15} = 1
+    $CURDIR/../linux_kernel_modules/can_9x15/can
+    $CURDIR/../linux_kernel_modules/can_9x15/can-bcm
+    $CURDIR/../linux_kernel_modules/can_9x15/can-raw
+    $CURDIR/../linux_kernel_modules/can_9x15/can-dev
+    $CURDIR/../linux_kernel_modules/can_9x15/vcan
+    $CURDIR/../linux_kernel_modules/can_9x15/mcp251x
+#elif ${MANGOH_WP_CHIPSET_9X07} = 1
+    $CURDIR/../linux_kernel_modules/can_9x07/mcp251x
+#elif ${MANGOH_WP_CHIPSET_9X28} = 1
+    $CURDIR/../linux_kernel_modules/can_9x07/mcp251x
+#endif  // MANGOH_WP_CHIPSET_?


### PR DESCRIPTION
I had a lot of trouble using the can iot module with the mangoh green and a wp76xx module.

With [help from zahid](https://forum.mangoh.io/t/can-patch-for-9x28-chips/2088/3) I was able to create a can support.

I committed the changes for other user who will maybe run into the same kind of problems.

It would also be helpfull if you would create a wiki page for x28 Modules.
I could assist creating it.