### PR TITLE
Update free GPIO when remove module

### DIFF
--- a/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
+++ b/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
@@ -452,7 +452,7 @@ static void ws_eink_deferred_io(struct fb_info *info,
 }
 
 static struct fb_deferred_io ws_eink_defio = {
-	.delay		= HZ / 30,
+	.delay		= HZ,
 	.deferred_io	= ws_eink_deferred_io,
 };
 

--- a/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
+++ b/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
@@ -318,16 +318,12 @@ static int ws_eink_update_display(struct ws_eink_fb_par *par)
 {
 	int ret = 0;
 	u8 *vmem = par->info->screen_base;
-
-#ifdef __LITTLE_ENDIAN
 	u8 *ssbuf = par->ssbuf;
 	memcpy(&ssbuf, &vmem, sizeof(vmem));
 	ret = set_frame_memory(par, ssbuf);
 	if (ret)
 		return ret;
-
 	ret = display_frame(par);
-#endif
 
 	return ret;
 }
@@ -534,13 +530,6 @@ static int ws_eink_spi_probe(struct spi_device *spi)
 	par->rst	= pdata->rst_gpio;
 	par->dc		= pdata->dc_gpio;
 	par->busy	= pdata->busy_gpio;
-
-#ifdef __LITTLE_ENDIAN
-	vmem = vzalloc(vmem_size);
-	if (!vmem)
-		return retval;
-	par->ssbuf = vmem;
-#endif
 
 	retval = register_framebuffer(info);
 	if (retval < 0) {


### PR DESCRIPTION
Update:
1. Add free GPIO when remove module to make sure all resource is cleaned.
2. Remove unnecessary checking _LITTLE_ENDIAN 
3. Update delay time for deferred_io