### PR TITLE
Improve CAN IoT card support

### DIFF
--- a/linux_kernel_modules/can_9x07/mcp251x.mdef
+++ b/linux_kernel_modules/can_9x07/mcp251x.mdef
@@ -2,12 +2,3 @@ sources:
 {
     mcp251x.c
 }
-
-requires:
-{
-    kernelModules:
-    {
-        $CURDIR/../can_common/can_iot
-    }
-}
-

--- a/linux_kernel_modules/can_9x15/mcp251x.mdef
+++ b/linux_kernel_modules/can_9x15/mcp251x.mdef
@@ -7,7 +7,6 @@ requires:
 {
     kernelModules:
     {
-        $CURDIR/../can_common/can_iot
 	$CURDIR/can-dev
     }
 }

--- a/linux_kernel_modules/can_common/can_iot.c
+++ b/linux_kernel_modules/can_common/can_iot.c
@@ -31,29 +31,41 @@ static struct mcp251x_platform_data mcp2515_pdata = {
 	.oscillator_frequency   = 16*1000*1000,
 };
 
-static struct spi_board_info mcp2515_board_info= {
+static struct spi_board_info mcp2515_board_info = {
 	.modalias       = "mcp2515",
 	.platform_data  = &mcp2515_pdata,
-	.max_speed_hz   = 2*1000*1000,
+	.max_speed_hz   = 2 * 1000 * 1000,
 	.mode           = SPI_MODE_0,
 	.bus_num        = 0,
 	.chip_select    = 0,
 };
 
-static struct spi_master *spi_master;
+
+static int interrupt_gpio = -1;
+module_param(interrupt_gpio, int, S_IRUGO);
+
 static struct spi_device *spi_device;
 
 static int __init can_iot_init(void)
 {
-	/* MCP251x needs us to allocate the GPIO irq it will request */
-	if ((gpio_request(CF3_GPIO42, "can_irq") == 0) &&
-	    (gpio_direction_input(CF3_GPIO42) == 0)) {
-		gpio_export(CF3_GPIO42, 0);
-		irq_set_irq_type(gpio_to_irq(CF3_GPIO42), IRQ_TYPE_EDGE_FALLING);
-	} else
-		pr_err("can_iot_init: Could not allocate the gpio irq for MCP251x CAN bus interrupt\n");
+	struct spi_master *spi_master;
 
-	mcp2515_board_info.irq = gpio_to_irq(CF3_GPIO42);
+	if (interrupt_gpio < 0) {
+		pr_err("module parameter interrupt_gpio (%d), must be set to a valid gpio number\n",
+		       interrupt_gpio);
+		return -EINVAL;
+	}
+
+	/* MCP251x needs us to allocate the GPIO irq it will request */
+	if ((gpio_request(interrupt_gpio, "can_irq") == 0) &&
+	    (gpio_direction_input(interrupt_gpio) == 0)) {
+		gpio_export(interrupt_gpio, 0);
+		mcp2515_board_info.irq = gpio_to_irq(interrupt_gpio);
+		irq_set_irq_type(mcp2515_board_info.irq, IRQ_TYPE_EDGE_FALLING);
+	} else {
+		pr_err("can_iot_init: Could not allocate the gpio irq for MCP251x CAN bus interrupt\n");
+		return -EINVAL;
+	}
 
 	/* Hook into the SPI bus */
 	spi_master = spi_busnum_to_master(PRIMARY_SPI_BUS);
@@ -62,16 +74,16 @@ static int __init can_iot_init(void)
 
 	spi_device = spi_new_device(spi_master, &mcp2515_board_info);
 	pr_info("can_iot_init: mcp2515 (gpio:%d  irq:%d).\n",
-		CF3_GPIO42, mcp2515_board_info.irq);
+		interrupt_gpio, mcp2515_board_info.irq);
 
 	/* platform_driver_register(&can_iot_drv);  */
 	return 0;
 }
 
-static void __exit can_iot_remove (void)
+static void __exit can_iot_remove(void)
 {
-	gpio_unexport(CF3_GPIO42);
-	gpio_free(CF3_GPIO42);
+	gpio_unexport(interrupt_gpio);
+	gpio_free(interrupt_gpio);
 	spi_unregister_device(spi_device);
 
 	/* platform_driver_unregister(&can_iot_drv);  */

--- a/linux_kernel_modules/can_common/can_iot.mdef
+++ b/linux_kernel_modules/can_common/can_iot.mdef
@@ -1,5 +1,39 @@
+load: manual
+
 sources:
 {
     can_iot.c
 }
 
+params:
+{
+#if ${MANGOH_WP_CHIPSET_9X15} = 1
+
+#if ${MANGOH_CAN_IOT_SLOT} = 0
+    interrupt_gpio = "80" // CF3_GPIO42
+#elif ${MANGOH_CAN_IOT_SLOT} = 1
+    interrupt_gpio = "73" // CF3_GPIO25
+#endif // MANGOH_CAN_IOT_SLOT
+
+#elif ${MANGOH_WP_CHIPSET_9X07} = 1
+
+#if ${MANGOH_CAN_IOT_SLOT} = 0
+    interrupt_gpio = "79" // CF3_GPIO42
+#elif ${MANGOH_CAN_IOT_SLOT} = 1
+    interrupt_gpio = "51" // CF3_GPIO25
+#endif // MANGOH_CAN_IOT_SLOT
+
+#endif // MANGOH_WP_CHIPSET_?
+}
+
+requires:
+{
+    kernelModules:
+    {
+#if ${MANGOH_WP_CHIPSET_9X15} = 1
+        $CURDIR/../can_9x15/mcp251x
+#elif ${MANGOH_WP_CHIPSET_9X07} = 1
+        $CURDIR/../can_9x07/mcp251x
+#endif  // MANGOH_WP_CHIPSET_?
+    }
+}

--- a/linux_kernel_modules/can_common/start_can.sh
+++ b/linux_kernel_modules/can_common/start_can.sh
@@ -1,25 +1,76 @@
+#!/bin/sh
+
 # It seems that taking the IoT card out of reset fails in the core
 # mangOH driver - but placing things after user-space has fully started
 # and through the SWI gpiolib-sysfs code works - TODO fix and move into
 # the core driver so no shell script is needed.
 # Thus, we remove the inserted chip driver and bring it back.
 
-drv_file=`find /legato/systems/current/modules/ -name "*mcp251x.ko"`
-drv=`basename $drv_file`
+usage () {
+    echo "\"$0 board [slot]\" where board is \"green\" or \"red\" and slot is \"0\" or \"1\""
+}
+
+if [ "$#" -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+if [ "$#" -gt 2 ]; then
+    usage
+    exit 1
+fi
+
+drv="can_iot.ko"
 # remove the driver
-rmmod $drv
+kmod unload $drv
 
-# Take IoT card out of reset
-echo 2 > /sys/class/gpio/export
-echo out  > /sys/class/gpio/gpio2/direction
-echo 1  > /sys/class/gpio/gpio2/value
+board=$1
+if [ "$board" = "green" ]; then
+    slot=0
+    if [ "$#" -eq 2 ]; then
+	slot=$2
+    fi
 
-# Enable level shifter on the CAN IoT card
-echo 13 > /sys/class/gpio/export
-echo out  > /sys/class/gpio/gpio13/direction
-echo 1  > /sys/class/gpio/gpio13/value
+    if [ "$slot" -eq 0 ]; then
+	# Output 1 to IoT slot 0 GPIO2
+	echo 33 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio33/direction
+	echo 1 > /sys/class/gpio/gpio33/value
+	# Route SPI to IoT slot 0
+	mux 4
+	# Reset IoT slot 0
+	mux 15
+    elif [ "$slot" -eq 1 ]; then
+	# Output 1 to IoT slot 0 GPIO2
+	echo 7 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio7/direction
+	echo 1 > /sys/class/gpio/gpio7/value
+	# Route SPI to IoT slot 1
+	mux 5
+	# Reset IoT slot 1
+	mux 16
+    else
+	echo "Invalid or unsupported slot $slot"
+	exit 1
+    fi
+
+elif [ "$board" = "red" ]; then
+    # Enable level shifter on the CAN IoT card by driving IoT GPIO2 high
+    echo 13 > /sys/class/gpio/export
+    echo out > /sys/class/gpio/gpio13/direction
+    echo 1  > /sys/class/gpio/gpio13/value
+
+    # Take IoT card out of reset
+    echo 2 > /sys/class/gpio/export
+    echo out > /sys/class/gpio/gpio2/direction
+    echo 1  > /sys/class/gpio/gpio2/value
+
+    # Give a bit of time for the IoT card to come out of reset before loading drivers
+    sleep 1
+fi
+
 
 # Bring driver back & iproute2 add in CAN
-insmod $drv_file
+kmod load $drv
 ip link set can0 type can bitrate 125000 triple-sampling on
 ifconfig can0 up

--- a/mangOH.sdef
+++ b/mangOH.sdef
@@ -121,7 +121,6 @@ componentSearch:
 
 kernelModules:
 {
-
 #if ${MANGOH_BOARD} = red
     $CURDIR/linux_kernel_modules/mangoh/mangoh_red
     $CURDIR/linux_kernel_modules/mt7697wifi/mt7697wifi_core
@@ -148,9 +147,6 @@ kernelModules:
     $CURDIR/linux_kernel_modules/mt7697q/mt7697q
     $CURDIR/linux_kernel_modules/mt7697serial/mt7697serial
 
-    // Uncomment to build for the CAN Bus IoT card on mangOH Red
-    // #include "sinc/mangoh_red_can_iot_card.sinc"
-
 #elif ${MANGOH_BOARD} = green
     $CURDIR/linux_kernel_modules/mangoh/mangoh_green_dv4
 
@@ -160,6 +156,7 @@ kernelModules:
      */
     $CURDIR/linux_kernel_modules/lsm6ds3/lsm6ds3-i2c
     $CURDIR/linux_kernel_modules/lsm6ds3/lsm6ds3
+	
 #elif ${MANGOH_BOARD} = yellow
     $CURDIR/linux_kernel_modules/mangoh/mangoh_yellow_dev
 #if ${MANGOH_KERNEL_LACKS_IIO} = 1
@@ -181,6 +178,8 @@ kernelModules:
     $CURDIR/linux_kernel_modules/cypwifi/cypwifi
 //    $CURDIR/linux_kernel_modules/cp2130/cp2130
 
-
 #endif // MANGOH_BOARD
 }
+
+// Uncomment to include support for the CAN IoT card
+// #include "sinc/can_iot_card.sinc"

--- a/sinc/can_iot_card.sinc
+++ b/sinc/can_iot_card.sinc
@@ -9,6 +9,19 @@
  * wp76/77 kernels include the CAN bus in the Kernel config as a built-in module, but not the chip
  * driver. Thus, only the chip driver is out of tree for wp76/77 kernels.
  */
+
+buildVars:
+{
+#if ${MANGOH_BOARD} = red
+    MANGOH_CAN_IOT_SLOT = 0
+#elif ${MANGOH_BOARD} = green
+    MANGOH_CAN_IOT_SLOT = 1
+    // MANGOH_CAN_IOT_SLOT = 0
+#endif // MANGOH_BOARD
+}
+
+kernelModules:
+{
     $CURDIR/../linux_kernel_modules/can_common/can_iot
 #if ${MANGOH_WP_CHIPSET_9X15} = 1
     $CURDIR/../linux_kernel_modules/can_9x15/can
@@ -20,3 +33,4 @@
 #elif ${MANGOH_WP_CHIPSET_9X07} = 1
     $CURDIR/../linux_kernel_modules/can_9x07/mcp251x
 #endif  // MANGOH_WP_CHIPSET_?
+}


### PR DESCRIPTION
Support 9x15 and 9x07 modules on mangOH Green IoT slots 0 and 1 and
mangOH Red IoT slot.