### PR TITLE
Update request gpio when initializing module

### DIFF
--- a/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
+++ b/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
@@ -274,22 +274,28 @@ static int display_frame(struct ws_eink_fb_par *par)
 static int ws_eink_init_display(struct ws_eink_fb_par *par)
 {
 	int ret;
+	struct device *dev = &par->spi->dev;
+	
+	ret = devm_gpio_request_one(&par->spi->dev, par->rst,
+				    GPIOF_OUT_INIT_LOW, "ws_eink_rst");
+	if (ret) {
+    	dev_err(dev, "Couldn't request reset GPIO\n");
+    	return ret;
+	}
 
-	gpio_request(par->rst, "ws_eink_rst");
-	gpio_request(par->dc, "ws_eink_dc");
-	gpio_request(par->busy, "ws_eink_busy");
+	ret = devm_gpio_request_one(&par->spi->dev, par->dc,
+				    GPIOF_OUT_INIT_LOW, "ws_eink_dc");
+	if (ret) {
+		dev_err(dev, "Couldn't request data/command GPIO\n");
+		return ret;
+	}
 
-	gpio_direction_output(par->dc, true);
-	gpio_set_value(par->dc, 0);
-	gpio_export(par->dc, true);
-
-	gpio_direction_output(par->rst, true);
-	gpio_set_value(par->rst, 0);
-	gpio_export(par->rst, true);
-
-	gpio_direction_input(par->busy);
-	gpio_set_value(par->busy, 0);
-	gpio_export(par->busy, true);
+	ret = devm_gpio_request_one(&par->spi->dev, par->busy,
+				    GPIOF_IN, "ws_eink_busy");
+	if (ret) {
+		dev_err(dev, "Couldn't request busy GPIO\n");
+		return ret;
+	}
 
 	ret = int_lut(par, lut_full_update, ARRAY_SIZE(lut_full_update));
 	if (ret)
@@ -312,13 +318,13 @@ static int ws_eink_update_display(struct ws_eink_fb_par *par)
 {
 	int ret = 0;
 	u8 *vmem = par->info->screen_base;
-
 	u8 *ssbuf = par->ssbuf;
+
 	memcpy(&ssbuf, &vmem, sizeof(vmem));
+
 	ret = set_frame_memory(par, ssbuf);
 	if (ret)
 		return ret;
-
 	ret = display_frame(par);
 
 	return ret;
@@ -448,7 +454,7 @@ static void ws_eink_deferred_io(struct fb_info *info,
 }
 
 static struct fb_deferred_io ws_eink_defio = {
-	.delay		= HZ / 30,
+	.delay		= HZ,
 	.deferred_io	= ws_eink_deferred_io,
 };
 
@@ -560,17 +566,11 @@ fballoc_fail:
 static int ws_eink_spi_remove(struct spi_device *spi)
 {
 	struct fb_info *p = spi_get_drvdata(spi);
-	struct waveshare_eink_platform_data *pdata;
-    pdata = spi->dev.platform_data;
-
-	gpio_free(pdata->rst_gpio);
-	gpio_free(pdata->dc_gpio);
-	gpio_free(pdata->busy_gpio);
-
 	unregister_framebuffer(p);
 	fb_dealloc_cmap(&p->cmap);
 	iounmap(p->screen_base);
 	framebuffer_release(p);
+
 
 	return 0;
 }


### PR DESCRIPTION
Hi David.

I have some update for e-ink driver module. Could you please help me to review and merge.

1. Remove export_gpio and update to use devm_gpio_request_one because don't need to export GPIO for user space using.
2. Remove _LITTLE_ENDIAN because of unnecessary _LITTLE_ENDIAN checking for ARM processors.
3. Change delay time for deferred_io from Hz/30 to Hz base on linux deferred_io document.
4. Fix indentation error.

Thanks
Thong Nguyen 
