### PR TITLE
ws_eink: Add fb_ioctl to support deep_sleep or wakeup for lcd

### DIFF
--- a/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
+++ b/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
@@ -341,11 +341,21 @@ static int ws_eink_update_display(struct ws_eink_fb_par *par)
 	int ret = 0;
 	u8 *vmem = par->info->screen_base;
 	u8 *ssbuf = par->ssbuf;
+
+	ret = int_lut(par, lut_partial_update, ARRAY_SIZE(lut_partial_update));
+	if (ret)
+		return ret;
+
 	memcpy(&ssbuf, &vmem, sizeof(vmem));
 	ret = set_frame_memory(par, ssbuf);
 	if (ret)
 		return ret;
+
 	ret = display_frame(par);
+	if (ret)
+		return ret;
+
+	ret = ws_eink_sleep(par);
 
 	return ret;
 }


### PR DESCRIPTION
Add fb_ioctl to framebuffer ops help to control deepsleep mode
for waveshare eink display from user space.
In user space can use ioctl(myfd, command,.) to set sleep mode or wakeup