### PR TITLE
define LEGATO_WIFI_PA for Cypress in yellow.sdef

### DIFF
--- a/shared.sdef
+++ b/shared.sdef
@@ -15,7 +15,6 @@ buildVars:
     MANGOH_ROOT = $CURDIR
 
     LEGATO_WIFI_ROOT = ${LEGATO_ROOT}/modules/WiFi
-    LEGATO_WIFI_PA = ${CURDIR}/linux_kernel_modules/cypwifi/scripts/pa_wifi.sh
 }
 
 apps:

--- a/yellow.sdef
+++ b/yellow.sdef
@@ -11,6 +11,8 @@ buildVars:
 {
     MANGOH_BOARD = yellow
 
+    LEGATO_WIFI_PA = ${CURDIR}/linux_kernel_modules/cypwifi/scripts/pa_wifi.sh
+
 #if ${MANGOH_WP_CHIPSET_9X07} = 1
     MANGOH_BME680_I2C_BUS = 6
 #elif ${MANGOH_WP_CHIPSET_9X15} = 1


### PR DESCRIPTION
Move the definition of LEGATO_WIFI_PA from shared.sdef into yellow.sdef
since the definition was only applicable to mangOH Yellow.

Resolves: #34