### PR TITLE
Add (incomplete but working) helloYellow app

### DIFF
--- a/apps/Welcome/components/yellowCommandLine/Component.cdef
+++ b/apps/Welcome/components/yellowCommandLine/Component.cdef
@@ -1,0 +1,11 @@
+sources:
+{
+    cmdLine.c
+}
+
+requires:
+{
+    api:
+    {
+    }
+}

--- a/apps/Welcome/components/yellowCommandLine/cmdLine.c
+++ b/apps/Welcome/components/yellowCommandLine/cmdLine.c
@@ -1,0 +1,9 @@
+#include "legato.h"
+#include "interfaces.h"
+
+COMPONENT_INIT
+{
+    printf("Yello!\n");
+
+    exit(EXIT_SUCCESS);
+}

--- a/apps/Welcome/components/yellowInstantGratification/Component.cdef
+++ b/apps/Welcome/components/yellowInstantGratification/Component.cdef
@@ -1,0 +1,12 @@
+sources:
+{
+    main.c
+}
+
+requires:
+{
+    api:
+    {
+        dhubAdmin = admin.api
+    }
+}

--- a/apps/Welcome/components/yellowInstantGratification/main.c
+++ b/apps/Welcome/components/yellowInstantGratification/main.c
@@ -1,0 +1,21 @@
+#include "legato.h"
+#include "interfaces.h"
+
+COMPONENT_INIT
+{
+    // Route button press events to the "vegas mode" trigger and the buzzer enable.
+    dhubAdmin_SetSource("/app/vegasMode/triggered/trigger", "/app/button/value");
+    dhubAdmin_SetSource("/app/buzzer/enable", "/app/button/value");
+
+    // Set the buzzer to 100% duty cycle, so it stays on as long as the button is held down.
+    dhubAdmin_SetNumericOverride("/app/buzzer/percent", 100.0);
+
+    // Route LED states from the vegasMode app to the LED control outputs.
+    dhubAdmin_SetSource("/app/leds/mono/enable", "/app/vegasMode/led/0");
+    dhubAdmin_SetSource("/app/leds/tri/red/enable", "/app/vegasMode/led/1");
+    dhubAdmin_SetSource("/app/leds/tri/green/enable", "/app/vegasMode/led/2");
+    dhubAdmin_SetSource("/app/leds/tri/blue/enable", "/app/vegasMode/led/3");
+
+    // Enable continuous (slow) Vegas Mode.
+    dhubAdmin_SetBooleanOverride("/app/vegasMode/continuous/enable", true);
+}

--- a/apps/Welcome/helloYellow.adef
+++ b/apps/Welcome/helloYellow.adef
@@ -1,0 +1,28 @@
+// Out-of-box experience app for the mangOH Yellow.
+//
+// This app is intended to provide some instant gratification when powering up a newly un-boxed
+// mangOH Yellow (even if there's no RF reception) and provide some useful bootstrapping functions,
+// like joining a WiFi network, checking for and installing updates, and registering with a
+// cellular connectivity and/or device management provider.
+//
+// Copyright (C) Sierra Wireless Inc.
+
+executables:
+{
+    instaGrat = ( components/yellowInstantGratification )
+    hello = ( components/yellowCommandLine )
+}
+
+processes:
+{
+    run:
+    {
+        ( instaGrat )
+    }
+}
+
+bindings:
+{
+    instaGrat.yellowInstantGratification.dhubAdmin -> dataHub.admin
+//    hello.yellowCommandLine.dhubAdmin -> dataHub.admin
+}

--- a/env_test_yellow.sdef
+++ b/env_test_yellow.sdef
@@ -1,11 +1,6 @@
 
 #include "yellow.sdef"
 
-buildVars:
-{
-    VEGAS_MODE_USLEEP = 1000000
-}
-
 apps:
 {
     apps/test/YellowEnvironment/dataLogger

--- a/yellow.sdef
+++ b/yellow.sdef
@@ -32,6 +32,8 @@ apps:
     apps/BatteryService/battery
     apps/VegasMode/vegasMode
 
+    apps/Welcome/helloYellow
+
     $LEGATO_ROOT/apps/tools/devMode
 }
 
@@ -43,6 +45,13 @@ bindings:
     button.dhubIO -> dataHub.io
     button.gpio -> gpioService.le_gpioPin25
     environment.dhubIO -> dataHub.io
+    vegasMode.dhubIO -> dataHub.io
+}
+
+
+commands:
+{
+    hello = helloYellow:/bin/hello
 }
 
 


### PR DESCRIPTION
Add the beginnings of the helloYellow app under apps/Welcome.
Add the helloYellow app to the yellow.sdef.
Remove old, dead build var from env_test_yellow.sdef.

WARNING: This depends on the new reworked VegasMode app.