### PR TITLE
Add changes for Yellow

### DIFF
--- a/linux_kernel_modules/can_common/can_iot.mdef
+++ b/linux_kernel_modules/can_common/can_iot.mdef
@@ -33,7 +33,9 @@ requires:
 #if ${MANGOH_WP_CHIPSET_9X15} = 1
         $CURDIR/../can_9x15/mcp251x
 #elif ${MANGOH_WP_CHIPSET_9X07} = 1
-        $CURDIR/../can_9x07/mcp251x
+        #if ${MANGOH_BOARD} = red
+             $CURDIR/../can_9x07/mcp251x
+        #endif
 #endif  // MANGOH_WP_CHIPSET_?
     }
 }

--- a/linux_kernel_modules/can_common/start_can.sh
+++ b/linux_kernel_modules/can_common/start_can.sh
@@ -7,7 +7,7 @@
 # Thus, we remove the inserted chip driver and bring it back.
 
 usage () {
-    echo "\"$0 board [slot]\" where board is \"green\" or \"red\" and slot is \"0\" or \"1\""
+    echo "\"$0 board [slot]\" where board is \"green\" or \"red\" or \"yellow\" and slot is \"0\" or \"1\""
 }
 
 if [ "$#" -lt 1 ]; then
@@ -54,7 +54,7 @@ if [ "$board" = "green" ]; then
 	exit 1
     fi
 
-elif [ "$board" = "red" ]; then
+elif [ "$board" = "red" ] || [ "$board" = "yellow" ]; then
     # Enable level shifter on the CAN IoT card by driving IoT GPIO2 high
     echo 13 > /sys/class/gpio/export
     echo out > /sys/class/gpio/gpio13/direction
@@ -67,8 +67,16 @@ elif [ "$board" = "red" ]; then
 
     # Give a bit of time for the IoT card to come out of reset before loading drivers
     sleep 1
+else
+    usage()
+    exit 1
 fi
 
+
+# For Yellow we have the meta-mangoh Yocto layer including the loadable module
+if [ "$board" = "yellow" ]; then
+    modprobe mcp251x
+fi
 
 # Bring driver back & iproute2 add in CAN
 kmod load $drv

--- a/sinc/can_iot_card.sinc
+++ b/sinc/can_iot_card.sinc
@@ -12,7 +12,9 @@
 
 buildVars:
 {
-#if ${MANGOH_BOARD} = red
+#if ${MANGOH_BOARD} = yellow
+    MANGOH_CAN_IOT_SLOT = 0
+#elif ${MANGOH_BOARD} = red
     MANGOH_CAN_IOT_SLOT = 0
 #elif ${MANGOH_BOARD} = green
     MANGOH_CAN_IOT_SLOT = 1
@@ -23,6 +25,7 @@ buildVars:
 kernelModules:
 {
     $CURDIR/../linux_kernel_modules/can_common/can_iot
+// TODO: we need to fix what's below for WP85 yellow with meta-mangoh
 #if ${MANGOH_WP_CHIPSET_9X15} = 1
     $CURDIR/../linux_kernel_modules/can_9x15/can
     $CURDIR/../linux_kernel_modules/can_9x15/can-bcm
@@ -31,6 +34,12 @@ kernelModules:
     $CURDIR/../linux_kernel_modules/can_9x15/vcan
     $CURDIR/../linux_kernel_modules/can_9x15/mcp251x
 #elif ${MANGOH_WP_CHIPSET_9X07} = 1
-    $CURDIR/../linux_kernel_modules/can_9x07/mcp251x
+    // Its possible to fix what's below for red/green with meta-mangoh
+    #if ${MANGOH_BOARD} = red
+         $CURDIR/../linux_kernel_modules/can_9x07/mcp251x
+    #endif
+    #if ${MANGOH_BOARD} = green
+         $CURDIR/../linux_kernel_modules/can_9x07/mcp251x
+    #endif
 #endif  // MANGOH_WP_CHIPSET_?
 }

--- a/yellow.sdef
+++ b/yellow.sdef
@@ -86,3 +86,4 @@ kernelModules:
     linux_kernel_modules/cypwifi/cypwifi
     linux_kernel_modules/cp2130/cp2130
 }
+


### PR DESCRIPTION
Note no testing was done on WP85.
The WP76xx assumes that the kernel's chip driver for the mcp251x is used, i.e. via meta-mangoh
Note Yellow DV3 boards need a resistor mod - will be fixed in DV4