### PR TITLE
Waveshare 213 Eink for yellow

### DIFF
--- a/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
+++ b/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
@@ -80,7 +80,7 @@ static int ws_eink_send_cmd(struct ws_eink_fb_par *par, u8 cmd, const u8 *data,
 	struct spi_device *spi = par->spi;
 	struct device *dev = &spi->dev;
 
-	gpio_set_value(par->dc, 0);
+	gpio_set_value_cansleep(par->dc, 0);
 	ret = spi_write(spi, &cmd, 1);
 	if (ret) {
 		dev_err(dev,
@@ -89,7 +89,7 @@ static int ws_eink_send_cmd(struct ws_eink_fb_par *par, u8 cmd, const u8 *data,
 		return ret;
 	}
 
-	gpio_set_value(par->dc, 1);
+	gpio_set_value_cansleep(par->dc, 1);
 	ret = spi_write(spi, data, data_size);
 	if (ret)
 		dev_err(dev,
@@ -101,15 +101,15 @@ static int ws_eink_send_cmd(struct ws_eink_fb_par *par, u8 cmd, const u8 *data,
 
 static void wait_until_idle(struct ws_eink_fb_par *par)
 {
-	while (gpio_get_value(par->busy) != 0)
+	while (gpio_get_value_cansleep(par->busy) != 0)
 		mdelay(100);
 }
 
 static void ws_eink_reset(struct ws_eink_fb_par *par)
 {
-	gpio_set_value(par->rst, 0);
+	gpio_set_value_cansleep(par->rst, 0);
 	mdelay(200);
-	gpio_set_value(par->rst, 1);
+	gpio_set_value_cansleep(par->rst, 1);
 	mdelay(200);
 }
 

--- a/experimental/waveshare_eink/linux_kernel_modules/mangOH_yellow_ws213.c
+++ b/experimental/waveshare_eink/linux_kernel_modules/mangOH_yellow_ws213.c
@@ -6,9 +6,7 @@
 #include <linux/spi/spi.h>
 #include <linux/gpio/driver.h>
 
-#if defined(CONFIG_ARCH_MSM9615) /* For WPX5XX */
-#include <../arch/arm/mach-msm/board-9615.h>
-#elif defined(CONFIG_ARCH_MDM9607) /* For WP76XX */
+#if defined(CONFIG_ARCH_MDM9607) /* For WP76XX, WP77XX */
 #include <../arch/arm/mach-msm/include/mach/swimcu.h>
 #endif
 
@@ -26,13 +24,8 @@ const char eink_device_name[] = "waveshare_213";
 static struct spi_device *eink_device;
 
 /* On the Yellow the busy gpio is off the IO expander unlike the Red */
-/* WP85 will not be supported on Yellow for now. */
-#if defined(CONFIG_ARCH_MSM9615)
-#define CF3_GPIO35	SWIMCU_GPIO_TO_SYS(1)
-#define CF3_GPIO40	SWIMCU_GPIO_TO_SYS(6)
-#define GPIO_OFFSET	1
-#elif defined(CONFIG_ARCH_MDM9607)
-#define CF3_GPIO35	 (37)
+#if defined(CONFIG_ARCH_MDM9607)
+#define CF3_GPIO35	(37)
 #define CF3_GPIO40	SWIMCU_GPIO_TO_SYS(3)
 #define GPIO_OFFSET	1
 #endif
@@ -45,9 +38,9 @@ static struct waveshare_eink_platform_data ws213_pdata = {
 
 static int gpiochip_match_name(struct gpio_chip *chip, void *data)
 {
-        const char *name = data;
+	const char *name = data;
 
-        return !strcmp(chip->label, name);
+	return !strcmp(chip->label, name);
 }
 
 static int __init add_ws213fb_device_to_bus(void)
@@ -77,15 +70,14 @@ static int __init add_ws213fb_device_to_bus(void)
 	eink_device->bits_per_word = 8;
 	eink_device->irq = -1;
 
-        /* If we find the expander for the busy GPIO we are ok */
-        expander_gpiop = gpiochip_find((void *) "sx1509q", gpiochip_match_name);
-        if (expander_gpiop == NULL) {
+	/* If we find the expander for the busy GPIO we are ok */
+	expander_gpiop = gpiochip_find((void *) "sx1509q", gpiochip_match_name);
+	if (expander_gpiop == NULL) {
 		printk(KERN_ALERT "Finding our gpiochip for the busy gpio failed\n");
 		status = -1;
 		goto put_master;
-        }
-        else
-                ws213_pdata.busy_gpio = expander_gpiop->base + GPIO_OFFSET;
+	}
+	ws213_pdata.busy_gpio = expander_gpiop->base + GPIO_OFFSET;
 
 	eink_device->dev.platform_data = &ws213_pdata;
 	eink_device->controller_state = NULL;

--- a/experimental/waveshare_eink/linux_kernel_modules/mangOH_yellow_ws213.c
+++ b/experimental/waveshare_eink/linux_kernel_modules/mangOH_yellow_ws213.c
@@ -1,0 +1,117 @@
+/* This files provides configuration data  & SPI setup for the
+ * Waveshare 213 for the mangOH Yellow.
+ */
+
+#include <linux/module.h>
+#include <linux/spi/spi.h>
+#include <linux/gpio/driver.h>
+
+#if defined(CONFIG_ARCH_MSM9615) /* For WPX5XX */
+#include <../arch/arm/mach-msm/board-9615.h>
+#elif defined(CONFIG_ARCH_MDM9607) /* For WP76XX */
+#include <../arch/arm/mach-msm/include/mach/swimcu.h>
+#endif
+
+#include "fb_waveshare_eink.h"
+
+#define SPI_BUS		32766
+#define SPI_BUS_CS1	1
+/*
+ * The minimum clock cycle duration supported by the waveshare 2.13 Inch display
+ * is 250ns which translates to 4MHz bus speed
+ */
+#define SPI_BUS_SPEED	4000000
+
+const char eink_device_name[] = "waveshare_213";
+static struct spi_device *eink_device;
+
+/* On the Yellow the busy gpio is off the IO expander unlike the Red */
+/* WP85 will not be supported on Yellow for now. */
+#if defined(CONFIG_ARCH_MSM9615)
+#define CF3_GPIO35	SWIMCU_GPIO_TO_SYS(1)
+#define CF3_GPIO40	SWIMCU_GPIO_TO_SYS(6)
+#define GPIO_OFFSET	1
+#elif defined(CONFIG_ARCH_MDM9607)
+#define CF3_GPIO35	 (37)
+#define CF3_GPIO40	SWIMCU_GPIO_TO_SYS(3)
+#define GPIO_OFFSET	1
+#endif
+
+static struct waveshare_eink_platform_data ws213_pdata = {
+	.rst_gpio	= CF3_GPIO35,
+	.dc_gpio	= CF3_GPIO40,
+	.busy_gpio	= -1,
+};
+
+static int gpiochip_match_name(struct gpio_chip *chip, void *data)
+{
+        const char *name = data;
+
+        return !strcmp(chip->label, name);
+}
+
+static int __init add_ws213fb_device_to_bus(void)
+{
+	struct spi_master *spi_master;
+	struct gpio_chip *expander_gpiop;
+	int status = 0;
+
+	spi_master = spi_busnum_to_master(SPI_BUS);
+	if (!spi_master) {
+		printk(KERN_ALERT "spi_busnum_to_master(%d) returned NULL\n",
+		       SPI_BUS);
+		return -1;
+	}
+
+	eink_device = spi_alloc_device(spi_master);
+	if (!eink_device) {
+		put_device(&spi_master->dev);
+		printk(KERN_ALERT "spi_alloc_device() failed\n");
+		status = -1;
+		goto put_master;
+	}
+
+	eink_device->chip_select = SPI_BUS_CS1;
+	eink_device->max_speed_hz = SPI_BUS_SPEED;
+	eink_device->mode = SPI_MODE_3;
+	eink_device->bits_per_word = 8;
+	eink_device->irq = -1;
+
+        /* If we find the expander for the busy GPIO we are ok */
+        expander_gpiop = gpiochip_find((void *) "sx1509q", gpiochip_match_name);
+        if (expander_gpiop == NULL) {
+		printk(KERN_ALERT "Finding our gpiochip for the busy gpio failed\n");
+		status = -1;
+		goto put_master;
+        }
+        else
+                ws213_pdata.busy_gpio = expander_gpiop->base + GPIO_OFFSET;
+
+	eink_device->dev.platform_data = &ws213_pdata;
+	eink_device->controller_state = NULL;
+	eink_device->controller_data = NULL;
+	strlcpy(eink_device->modalias, eink_device_name, SPI_NAME_SIZE);
+
+	status = spi_add_device(eink_device);
+	if (status < 0) {
+		spi_dev_put(eink_device);
+		printk(KERN_ALERT "spi_add_device() failed: %d\n", status);
+	}
+
+put_master:
+	put_device(&spi_master->dev);
+
+	return status;
+}
+module_init(add_ws213fb_device_to_bus);
+
+static void __exit exit_ws213fb_device(void)
+{
+	spi_unregister_device(eink_device);
+}
+module_exit(exit_ws213fb_device);
+
+MODULE_AUTHOR("Sierra Wireless");
+MODULE_DESCRIPTION("Bind device driver to SPI ws213 e-ink display");
+MODULE_LICENSE("GPL");
+MODULE_VERSION("0.1");

--- a/experimental/waveshare_eink/linux_kernel_modules/mangOH_yellow_ws213.mdef
+++ b/experimental/waveshare_eink/linux_kernel_modules/mangOH_yellow_ws213.mdef
@@ -1,0 +1,16 @@
+sources:
+{
+    mangOH_yellow_ws213.c
+}
+
+cflags:
+{
+    -DCONFIG_FBWS
+    -DCONFIG_RPIFB
+}
+
+params:
+{
+}
+
+load: manual


### PR DESCRIPTION
Added new configs/defs for yellow
On the Yellow the busy gpio is off the IO expander unlike the Red
On the WP76xx kernel the gpio_set/get_value spew out continous WARN stack traces - made all sleepable to remove WARNs.