### PR TITLE
Work around spiService start-up race

### DIFF
--- a/default.sdef
+++ b/default.sdef
@@ -1,0 +1,73 @@
+//--------------------------------------------------------------------------------------------------
+// Sample system definition that includes essential modem and positioning services.
+//
+// Copyright (C) Sierra Wireless Inc.
+//--------------------------------------------------------------------------------------------------
+
+#include "$LEGATO_ROOT/legatoTargetConfig.sinc"
+
+#include "$LEGATO_ROOT/apps/platformServices/defaultAirVantage.sinc"
+#include "$LEGATO_ROOT/apps/platformServices/defaultAtCommands.sinc"
+#if ${LEGATO_EXTRA_SINC} = ""
+#else
+    #include "$LEGATO_EXTRA_SINC"
+#endif
+
+apps:
+{
+    // Platform services.
+    $LEGATO_ROOT/apps/platformServices/audioService
+    $LEGATO_ROOT/apps/platformServices/cellNetService
+    $LEGATO_ROOT/apps/platformServices/dataConnectionService
+    $LEGATO_ROOT/apps/platformServices/fwupdateService
+    $LEGATO_ROOT/apps/platformServices/modemService
+    $LEGATO_ROOT/apps/platformServices/positioningService
+    $LEGATO_ROOT/apps/platformServices/powerMgr
+    $LEGATO_ROOT/apps/platformServices/secStore
+    $LEGATO_ROOT/apps/platformServices/smsInboxService
+    $LEGATO_ROOT/apps/platformServices/voiceCallService
+    $LEGATO_ROOT/apps/platformServices/gpioService
+    $LEGATO_ROOT/apps/platformServices/atService
+    $LEGATO_ROOT/apps/platformServices/spiService
+    $LEGATO_ROOT/apps/platformServices/portService
+
+    // Command-line tools.
+    $LEGATO_ROOT/apps/tools/tools
+
+#if ${LE_CONFIG_RPC} = y
+    $LEGATO_ROOT/framework/daemons/rpcProxy/rpcProxy
+#endif
+}
+
+#if ${LE_CONFIG_FEATURE_SPISVC} = y
+kernelModules:
+{
+//    $LEGATO_ROOT/drivers/spisvc/spisvc.mdef
+}
+#endif
+
+commands:
+{
+    cm = tools:/scripts/cm
+    fwupdate = tools:/bin/fwupdate
+    secstore = tools:/bin/secstore
+    pmtool = tools:/bin/pmtool
+    gnss = tools:/bin/gnss
+    uartMode = tools:/bin/uartMode
+    kmod = tools:/bin/kmod
+#if ${LE_CONFIG_RPC} = y
+    rpctool = tools:/bin/rpcTool
+#endif
+}
+
+bindings:
+{
+    <root>.le_fwupdate -> fwupdateService.le_fwupdate
+}
+
+interfaceSearch:
+{
+    $LEGATO_ROOT/interfaces/modemServices
+    $LEGATO_ROOT/interfaces/positioning
+    $LEGATO_ROOT/interfaces/atServices
+}

--- a/linux_kernel_modules/spisvc/scripts/install.sh
+++ b/linux_kernel_modules/spisvc/scripts/install.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+echo "+++++++++++++++++++++++++++++++++++++++++" > /dev/console
+
+KO_PATH=$1
+
+modprobe -q spidev
+insmod "$KO_PATH"
+
+# Make 10 attempts to check whether dev file exists
+# Sleep 1s in between
+
+for i in $(seq 1 10)
+do
+  if [ ! "$(find /dev/spidev* 2> /dev/null | wc -l)" -eq "0" ]
+  then
+    exit 0
+  fi
+  sleep 1
+done
+
+# return error if device file hasn't been created after timeout
+if [ "$i" -eq "10" ]
+then
+  exit 1
+fi
+
+exit 0

--- a/linux_kernel_modules/spisvc/scripts/remove.sh
+++ b/linux_kernel_modules/spisvc/scripts/remove.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "---------------------------------------------" > /dev/console
+
+KO_PATH=$1
+
+rmmod $KO_PATH
+modprobe -rq spidev
+
+exit 0

--- a/linux_kernel_modules/spisvc/spisvc.c
+++ b/linux_kernel_modules/spisvc/spisvc.c
@@ -1,0 +1,83 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the version 2 of the GNU General Public License
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2016 Sierra Wireless Inc.
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/spi/spi.h>
+
+#define MOD_DESC "Spidev creation module"
+
+MODULE_DESCRIPTION(MOD_DESC);
+MODULE_LICENSE("GPL v2");
+MODULE_AUTHOR("Sierra Wireless, Inc.");
+
+#define SPI_INVALID_BUS (-1)
+int busnum = SPI_INVALID_BUS;
+module_param(busnum, int, 0644);
+MODULE_PARM_DESC(busnum, "SPI bus number");
+
+unsigned int cs = 0;
+module_param(cs, uint, 0644);
+MODULE_PARM_DESC(cs, "SPI chip select");
+
+#define SPI_MAX_BUS	16	/* take a reasonable number */
+
+static struct spi_device *spidev;
+
+static __init int spisvc_init(void)
+{
+	struct spi_master *m = NULL;
+	struct spi_board_info board = {
+		.modalias = "spidev",
+		.max_speed_hz = 15058800,
+		.mode = SPI_MODE_3,
+		.platform_data = NULL,
+		.bus_num = 0,
+		.chip_select = 0,
+		.irq = 0,
+	};
+
+	if (SPI_INVALID_BUS == busnum)
+		/* Bus not assigned: find SPI master with lowest bus number */
+		for (busnum = 0; SPI_MAX_BUS > busnum && NULL == m; busnum++)
+			m = spi_busnum_to_master(busnum);
+	else
+		m = spi_busnum_to_master(busnum);
+
+	if (!m) {
+		pr_err("SPI bus not available.\n");
+		return -ENODEV;
+	}
+
+	board.bus_num = busnum = m->bus_num;
+	board.chip_select = cs;
+	spidev = spi_new_device(m, &board);
+	if (!spidev) {
+		dev_err(&m->dev, "Cannot add '%s' on bus %u, cs %u\n",
+			board.modalias, board.bus_num, board.chip_select);
+		return -ENODEV;
+	}
+	return 0;
+}
+module_init(spisvc_init);
+
+static __exit void spisvc_exit(void)
+{
+	if (spidev)
+		spi_unregister_device(spidev);
+}
+module_exit(spisvc_exit);
+

--- a/linux_kernel_modules/spisvc/spisvc.mdef
+++ b/linux_kernel_modules/spisvc/spisvc.mdef
@@ -1,0 +1,24 @@
+//-------------------------------------------------------------------------------------------------
+// Definition file for spisvc kernel module.
+//
+// Inserting this kernel module results in the creation of a spidev-type device /dev/spidev0.0.
+// Removing this module removes the device. The device uses CS0 so any other SPI driver attempting
+// to use the same chip-select would report a conflict.
+//
+// For use with a mangOH reference design, SPI device has to be plugged into IoT slot 0.
+//
+// Copyright (C) Sierra Wireless Inc.
+//-------------------------------------------------------------------------------------------------
+
+sources:
+{
+    spisvc.c
+}
+
+load: auto
+
+scripts:
+{
+    install: $CURDIR/scripts/install.sh
+    remove: $CURDIR/scripts/remove.sh
+}

--- a/shared.sdef
+++ b/shared.sdef
@@ -7,7 +7,7 @@
 // Copyright (C) Sierra Wireless Inc.
 //--------------------------------------------------------------------------------------------------
 
-#include "$LEGATO_ROOT/modules/WiFi/wifi.sdef"
+#include "wifi.sdef"
 #include "sinc/module/${LEGATO_TARGET}.sinc"
 
 buildVars:

--- a/wifi.sdef
+++ b/wifi.sdef
@@ -1,0 +1,30 @@
+//--------------------------------------------------------------------------------------------------
+// Sample system definition that includes essential services and WiFi-related services and sample
+// applications.
+//
+// Copyright (C) Sierra Wireless Inc.
+//--------------------------------------------------------------------------------------------------
+
+#include "default.sdef"
+
+buildVars:
+{
+    LEGATO_WIFI_ROOT=${LEGATO_ROOT}/modules/WiFi
+    // File is selected by users, replace "ti" with "qca" to support qca chipset
+    LEGATO_WIFI_PA=${LEGATO_WIFI_ROOT}/service/platformAdaptor/ti/pa_wifi.sh
+}
+
+apps:
+{
+    // WiFi services
+    $LEGATO_WIFI_ROOT/service/wifiService.adef
+    $LEGATO_WIFI_ROOT/apps/sample/wifiClientTest/wifiClientTest.adef
+    $LEGATO_WIFI_ROOT/apps/sample/wifiApTest/wifiApTest.adef
+    $LEGATO_WIFI_ROOT/apps/sample/wifiWebAp/wifiWebAp.adef
+    $LEGATO_WIFI_ROOT/apps/tools/wifi/wifi.adef
+}
+
+commands:
+{
+    wifi = wifi:/bin/wifi
+}

--- a/yellow.sdef
+++ b/yellow.sdef
@@ -60,6 +60,7 @@ interfaceSearch:
     apps/BatteryService
     apps/Bme680EnvironmentalSensor
     apps/YellowSensorToCloud/interfaces
+    $LEGATO_ROOT/interfaces/wifi
 }
 
 
@@ -85,4 +86,5 @@ kernelModules:
     linux_kernel_modules/expander/expander
     linux_kernel_modules/cypwifi/cypwifi
     linux_kernel_modules/cp2130/cp2130
+    linux_kernel_modules/spisvc/spisvc
 }


### PR DESCRIPTION
The spiService was failing to start up because the spisvc
kernel module was slow to create its device file and the
Supervisor was trying to add that file to the spiService's
working directory before the file was created.

Worked around this by making the spisvc load at Legato
start-up instead of at app start-up.

Unfortunately, this requires forking a bunch of stuff
from the Legato framework into the mangOH project, so we
can change it slightly.