### PR TITLE
Added CURDIR back in

### DIFF
--- a/env_test_yellow.sdef
+++ b/env_test_yellow.sdef
@@ -1,7 +1,17 @@
+#---------------------------------------------------------------------------------------------------
+# System definition for use with mangOH Yellow when running it in the environmental test chamber.
+# This just logs a bunch of the sensor readings to flash.
+#
+# In addition, it is recommended that /etc/syslog-startup.conf be configured to log syslog
+# to flash (/home/root/syslog) instead of to circular RAM buffer, to allow post-mortem
+# troubleshooting in case something goes wrong.
+#
+# Copyright (C) Sierra Wireless Inc.
+#---------------------------------------------------------------------------------------------------
 
 #include "yellow.sdef"
 
 apps:
 {
-    apps/test/YellowEnvironment/dataLogger
+    $CURDIR/apps/test/YellowEnvironment/dataLogger
 }

--- a/green.sdef
+++ b/green.sdef
@@ -15,14 +15,14 @@ buildVars:
 
 apps:
 {
-    apps/GpioExpander/gpioExpanderService/gpioExpanderServiceGreen
-    apps/MuxControl/muxCtrlService/muxCtrlService
-    apps/MuxControl/tools/muxCtrlTools
-    apps/DataRouter/dataRouter
-    apps/DataRouter/drTool/drTool
-    apps/ArduinoBridge/arduinoBridge
-    apps/Heartbeat/heartbeatGreen
-    apps/MqttClient/mqttClient
+    $CURDIR/apps/GpioExpander/gpioExpanderService/gpioExpanderServiceGreen
+    $CURDIR/apps/MuxControl/muxCtrlService/muxCtrlService
+    $CURDIR/apps/MuxControl/tools/muxCtrlTools
+    $CURDIR/apps/DataRouter/dataRouter
+    $CURDIR/apps/DataRouter/drTool/drTool
+    $CURDIR/apps/ArduinoBridge/arduinoBridge
+    $CURDIR/apps/Heartbeat/heartbeatGreen
+    $CURDIR/apps/MqttClient/mqttClient
 }
 
 
@@ -35,28 +35,28 @@ commands:
 
 interfaceSearch:
 {
-    apps/MuxControl
-    apps/DataRouter
-    apps/MqttClient
+    $CURDIR/apps/MuxControl
+    $CURDIR/apps/DataRouter
+    $CURDIR/apps/MqttClient
 }
 
 
 componentSearch:
 {
-    apps/GpioExpander/gpioExpanderService
+    $CURDIR/apps/GpioExpander/gpioExpanderService
 }
 
 
 kernelModules:
 {
-    linux_kernel_modules/mangoh/mangoh_green_dv4
+    $CURDIR/linux_kernel_modules/mangoh/mangoh_green_dv4
 
     /*
      * Dependencies of the above kernel modules - must be listed explicitly in the SDEF due to the
      * way that Legato kernel module dependencies work
      */
-    linux_kernel_modules/lsm6ds3/lsm6ds3-i2c
-    linux_kernel_modules/lsm6ds3/lsm6ds3
+    $CURDIR/linux_kernel_modules/lsm6ds3/lsm6ds3-i2c
+    $CURDIR/linux_kernel_modules/lsm6ds3/lsm6ds3
 }
 
 // Uncomment to include support for the CAN IoT card

--- a/red.sdef
+++ b/red.sdef
@@ -15,9 +15,9 @@ buildVars:
 
 apps:
 {
-    apps/LedService/ledService
-    apps/RedSensorToCloud/redSensorToCloud
-    apps/BatteryService/battery
+    $CURDIR/apps/LedService/ledService
+    $CURDIR/apps/RedSensorToCloud/redSensorToCloud
+    $CURDIR/apps/BatteryService/battery
 }
 
 
@@ -29,46 +29,46 @@ bindings:
 
 interfaceSearch:
 {
-    apps/BatteryService
+    $CURDIR/apps/BatteryService
 }
 
 
 componentSearch:
 {
-    apps/RedSensorToCloud
-    apps/BatteryService
+    $CURDIR/apps/RedSensorToCloud
+    $CURDIR/apps/BatteryService
 }
 
 
 kernelModules:
 {
-    linux_kernel_modules/mangoh/mangoh_red
-    linux_kernel_modules/mt7697wifi/mt7697wifi_core
+    $CURDIR/linux_kernel_modules/mangoh/mangoh_red
+    $CURDIR/linux_kernel_modules/mt7697wifi/mt7697wifi_core
 
     /*
      * Dependencies of the above kernel modules - must be listed explicitly in the SDEF due to the
      * way that Legato kernel module dependencies work
      */
-    linux_kernel_modules/led/led
-    linux_kernel_modules/bq24296/bq24296
-    linux_kernel_modules/ltc294x/ltc294x
-    linux_kernel_modules/bq27xxx/bq27xxx_battery
-    linux_kernel_modules/cp2130/cp2130
-    linux_kernel_modules/bmp280/bmp280-i2c
-    linux_kernel_modules/bmp280/bmp280
-    linux_kernel_modules/bmi160/bmi160-i2c
-    linux_kernel_modules/bmi160/bmi160
+    $CURDIR/linux_kernel_modules/led/led
+    $CURDIR/linux_kernel_modules/bq24296/bq24296
+    $CURDIR/linux_kernel_modules/ltc294x/ltc294x
+    $CURDIR/linux_kernel_modules/bq27xxx/bq27xxx_battery
+    $CURDIR/linux_kernel_modules/cp2130/cp2130
+    $CURDIR/linux_kernel_modules/bmp280/bmp280-i2c
+    $CURDIR/linux_kernel_modules/bmp280/bmp280
+    $CURDIR/linux_kernel_modules/bmi160/bmi160-i2c
+    $CURDIR/linux_kernel_modules/bmi160/bmi160
 
     #if ${MANGOH_KERNEL_LACKS_IIO} = 1
 
-        linux_kernel_modules/iio/iio-triggered-buffer
-        linux_kernel_modules/iio/iio-kfifo-buf
-        linux_kernel_modules/iio/iio
+        $CURDIR/linux_kernel_modules/iio/iio-triggered-buffer
+        $CURDIR/linux_kernel_modules/iio/iio-kfifo-buf
+        $CURDIR/linux_kernel_modules/iio/iio
 
     #endif // MANGOH_KERNEL_LACKS_IIO
 
-    linux_kernel_modules/mt7697q/mt7697q
-    linux_kernel_modules/mt7697serial/mt7697serial
+    $CURDIR/linux_kernel_modules/mt7697q/mt7697q
+    $CURDIR/linux_kernel_modules/mt7697serial/mt7697serial
 }
 
 // Uncomment to include support for the CAN IoT card

--- a/shared.sdef
+++ b/shared.sdef
@@ -19,7 +19,7 @@ buildVars:
 
 apps:
 {
-    apps/DataHub/dataHub
+    $CURDIR/apps/DataHub/dataHub
     {
         maxFileBytes: 4000K
     }
@@ -32,19 +32,19 @@ commands:
 
 interfaceSearch:
 {
-    interfaces
-    apps/LedService
-    apps/DataHub
-    apps/DataHub/components/periodicSensor
+    $CURDIR/interfaces
+    $CURDIR/apps/LedService
+    $CURDIR/apps/DataHub
+    $CURDIR/apps/DataHub/components/periodicSensor
 }
 
 componentSearch:
 {
-    components
-    apps/DataHub/components
+    $CURDIR/components
+    $CURDIR/apps/DataHub/components
 }
 
 kernelModules:
 {
-    linux_kernel_modules/spisvc/spisvc
+    $CURDIR/linux_kernel_modules/spisvc/spisvc
 }

--- a/yellow.sdef
+++ b/yellow.sdef
@@ -23,16 +23,16 @@ buildVars:
 
 apps:
 {
-    apps/YellowSensorToCloud/imu
-    apps/YellowSensorToCloud/light
-    apps/YellowSensorToCloud/button
-    apps/Bme680EnvironmentalSensor/environment
-    apps/DataHub-Buzzer/buzzer
-    apps/YellowOnBoardActuators/leds
-    apps/BatteryService/battery
-    apps/VegasMode/vegasMode
+    $CURDIR/apps/YellowSensorToCloud/imu
+    $CURDIR/apps/YellowSensorToCloud/light
+    $CURDIR/apps/YellowSensorToCloud/button
+    $CURDIR/apps/Bme680EnvironmentalSensor/environment
+    $CURDIR/apps/DataHub-Buzzer/buzzer
+    $CURDIR/apps/YellowOnBoardActuators/leds
+    $CURDIR/apps/BatteryService/battery
+    $CURDIR/apps/VegasMode/vegasMode
 
-    apps/Welcome/helloYellow
+    $CURDIR/apps/Welcome/helloYellow
 
     $LEGATO_ROOT/apps/tools/devMode
 }
@@ -57,33 +57,33 @@ commands:
 
 interfaceSearch:
 {
-    apps/BatteryService
-    apps/Bme680EnvironmentalSensor
-    apps/YellowSensorToCloud/interfaces
+    $CURDIR/apps/BatteryService
+    $CURDIR/apps/Bme680EnvironmentalSensor
+    $CURDIR/apps/YellowSensorToCloud/interfaces
     $LEGATO_ROOT/interfaces/wifi
 }
 
 
 componentSearch:
 {
-    apps/BatteryService
-    apps/YellowSensorToCloud/components
+    $CURDIR/apps/BatteryService
+    $CURDIR/apps/YellowSensorToCloud/components
 }
 
 
 kernelModules:
 {
-    linux_kernel_modules/mangoh/mangoh_yellow_dev
-    linux_kernel_modules/bmi160/bmi160-i2c
-    linux_kernel_modules/bmi160/bmi160
-    linux_kernel_modules/bmm150/bmc150_magn_i2c
-    linux_kernel_modules/bmm150/bmc150_magn
-    linux_kernel_modules/rtc-pcf85063/rtc-pcf85063
-    linux_kernel_modules/rtc_sync/rtc_sync
-    linux_kernel_modules/bq25601/bq25601
-    linux_kernel_modules/bq27xxx/bq27xxx_battery
-    linux_kernel_modules/opt300x/opt300x
-    linux_kernel_modules/expander/expander
-    linux_kernel_modules/cypwifi/cypwifi
-    linux_kernel_modules/cp2130/cp2130
+    $CURDIR/linux_kernel_modules/mangoh/mangoh_yellow_dev
+    $CURDIR/linux_kernel_modules/bmi160/bmi160-i2c
+    $CURDIR/linux_kernel_modules/bmi160/bmi160
+    $CURDIR/linux_kernel_modules/bmm150/bmc150_magn_i2c
+    $CURDIR/linux_kernel_modules/bmm150/bmc150_magn
+    $CURDIR/linux_kernel_modules/rtc-pcf85063/rtc-pcf85063
+    $CURDIR/linux_kernel_modules/rtc_sync/rtc_sync
+    $CURDIR/linux_kernel_modules/bq25601/bq25601
+    $CURDIR/linux_kernel_modules/bq27xxx/bq27xxx_battery
+    $CURDIR/linux_kernel_modules/opt300x/opt300x
+    $CURDIR/linux_kernel_modules/expander/expander
+    $CURDIR/linux_kernel_modules/cypwifi/cypwifi
+    $CURDIR/linux_kernel_modules/cp2130/cp2130
 }


### PR DESCRIPTION
When running mksys from a different directory, many of the paths
found in the .sdef files no longer worked.