### PR TITLE
Comment-out unneeded apps to reduce size

### DIFF
--- a/default.sdef
+++ b/default.sdef
@@ -24,7 +24,6 @@ apps:
     $LEGATO_ROOT/apps/platformServices/positioningService
     $LEGATO_ROOT/apps/platformServices/powerMgr
     $LEGATO_ROOT/apps/platformServices/secStore
-//    $LEGATO_ROOT/apps/platformServices/smsInboxService
     $LEGATO_ROOT/apps/platformServices/voiceCallService
     $LEGATO_ROOT/apps/platformServices/gpioService
     $LEGATO_ROOT/apps/platformServices/atService

--- a/default.sdef
+++ b/default.sdef
@@ -24,7 +24,7 @@ apps:
     $LEGATO_ROOT/apps/platformServices/positioningService
     $LEGATO_ROOT/apps/platformServices/powerMgr
     $LEGATO_ROOT/apps/platformServices/secStore
-    $LEGATO_ROOT/apps/platformServices/smsInboxService
+//    $LEGATO_ROOT/apps/platformServices/smsInboxService
     $LEGATO_ROOT/apps/platformServices/voiceCallService
     $LEGATO_ROOT/apps/platformServices/gpioService
     $LEGATO_ROOT/apps/platformServices/atService

--- a/wifi.sdef
+++ b/wifi.sdef
@@ -18,9 +18,9 @@ apps:
 {
     // WiFi services
     $LEGATO_WIFI_ROOT/service/wifiService.adef
-    $LEGATO_WIFI_ROOT/apps/sample/wifiClientTest/wifiClientTest.adef
-    $LEGATO_WIFI_ROOT/apps/sample/wifiApTest/wifiApTest.adef
-    $LEGATO_WIFI_ROOT/apps/sample/wifiWebAp/wifiWebAp.adef
+//    $LEGATO_WIFI_ROOT/apps/sample/wifiClientTest/wifiClientTest.adef
+//    $LEGATO_WIFI_ROOT/apps/sample/wifiApTest/wifiApTest.adef
+//    $LEGATO_WIFI_ROOT/apps/sample/wifiWebAp/wifiWebAp.adef
     $LEGATO_WIFI_ROOT/apps/tools/wifi/wifi.adef
 }
 

--- a/wifi.sdef
+++ b/wifi.sdef
@@ -18,9 +18,6 @@ apps:
 {
     // WiFi services
     $LEGATO_WIFI_ROOT/service/wifiService.adef
-//    $LEGATO_WIFI_ROOT/apps/sample/wifiClientTest/wifiClientTest.adef
-//    $LEGATO_WIFI_ROOT/apps/sample/wifiApTest/wifiApTest.adef
-//    $LEGATO_WIFI_ROOT/apps/sample/wifiWebAp/wifiWebAp.adef
     $LEGATO_WIFI_ROOT/apps/tools/wifi/wifi.adef
 }
 


### PR DESCRIPTION
When Octave support is added, the .cwe file becomes too large to fit
in the legato partition in WP modules. Removing a few apps that we
don't really need works around this issue.