### PR TITLE
Make factory spk generation more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,3 @@ build/%_$(LEGATO_TARGET).spk: build/%_$(LEGATO_TARGET)/legato.cwe
 	@echo "  Linux kernel and root file system = $(LINUX_IMAGE)"
 	@echo "  Legato framework and apps = $<"
 	@echo "Output written to $@"
-
-# Default rule that will get run for .spk files that we don't support yet.
-build/%.spk:
-	$(error Factory .spk file generation not yet supported for "$*")


### PR DESCRIPTION
- Search for modem firmware, preferring SIERRA, falling back to
  first GENERIC seen.
- Replace wp76 with a wildcard.
- Allow modem image and linux image to be specified on command line
  or in the environment.
- Display results of image selection so it can be checked by a
  human.