### PR TITLE
Make more friendly when don't have Octave apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,18 @@
 #  * If the Legato version in LEGATO_ROOT is < 18.02.0, then it will be necessary to do "export
 #    LEGATO_SYSROOT=$XXXX_SYSROOT" where XXXX is the module the build is for.
 #
-# By default, the Legato framework will be built before building the mangOH software.
-# Set LEGATO=0 to skip this step.
+# By default, the Legato framework will not be built before building the mangOH software.
+# Set LEGATO=1 to trigger a build of the Legato framework first.
+# WARNING: Do not use LEGATO=1 when using a Legato provided by leaf. This will result in the
+# modification of files within ~/leaf-data which may be shared between many leaf workspaces
+# and leaf profiles.
+#
+# To build with optional Octave(tm) support, set OCTAVE_ROOT to contain the path to directory
+# containing the .app files for the Octave applications (such as cloudInterface.wp77xx.app).
+# You also have the option of setting OCTAVE=0 to disable inclusion of Octave support even
+# when OCTAVE_ROOT is set.
+#
+# Copyright (C) Sierra Wireless Inc.
 
 UPDATE_FILE_DIR = build/update_files
 LEAF_DATA = ../leaf-data/current
@@ -24,6 +34,7 @@ MAKEFILE_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 export BSEC_DIR ?= $(MAKEFILE_DIR)components/boschBsec/BSEC_1.4.7.2_GCC_CortexA7_20190225/algo/bin/Normal_version/Cortex_A7
 
 # The comments below are for Developer Studio integration. Do not remove them.
+# WARNING: Developer Studio has reached end-of-life and will not be supported in future.
 # DS_CLONE_ROOT(CURDIR)
 # DS_CUSTOM_OPTIONS(MKSYS_ARGS_COMMON)
 
@@ -55,7 +66,7 @@ all: $(ALL_COMBINATIONS)
 # Until Legato allows external builds in mdefs we will need to build a
 # subsystem driver like Cypress Wifi in the top Makefile and with scripts
 # define a function to build the Cypress driver for different architectures
-
+#
 # $(call cyp_bld,$(board)_$(module))
 # E.g., $(call cyp_bld,yellow_wp76xx)
 define cyp_bld
@@ -82,12 +93,15 @@ else
 	$(MAKE) -C $(LEGATO_ROOT) framework_$(LEGATO_TARGET)
 endif
 
-# If OCTAVE_ROOT is defined, include Octave for mangOH Yellow builds by default.
-ifdef OCTAVE_ROOT
-  yellow_%: OCTAVE ?= 1
-else
-  $(warning ==== OCTAVE_ROOT not defined ====)
-  yellow_%: OCTAVE ?= 0
+# If OCTAVE_ROOT is defined, include Octave in mangOH Yellow builds by default.
+# ...but we don't care about this if we are cleaning.
+ifneq ($(MAKECMDGOALS),clean)
+  ifdef OCTAVE_ROOT
+    yellow_%: OCTAVE ?= 1
+  else
+    $(warning ==== OCTAVE_ROOT not defined ====)
+    yellow_%: OCTAVE ?= 0
+  endif
 endif
 
 # Build goals that get the target WP module type from the LEGATO_TARGET environment variable.

--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,18 @@ LEGATO ?= 0
 legato_%:
 	$(eval export LEGATO_TARGET := $(subst legato_,,$@))
 ifeq ($(LEGATO),0)
-	echo "Not building LEGATO due to \$$LEGATO == 0"
+	@echo "Not building LEGATO due to \$$LEGATO == 0"
 else
 	$(MAKE) -C $(LEGATO_ROOT) framework_$(LEGATO_TARGET)
 endif
 
-# Default to including octave for mangOH Yellow builds
-yellow_%: OCTAVE ?= 1
+# If OCTAVE_ROOT is defined, include Octave for mangOH Yellow builds by default.
+ifdef OCTAVE_ROOT
+  yellow_%: OCTAVE ?= 1
+else
+  $(warning ==== OCTAVE_ROOT not defined ====)
+  yellow_%: OCTAVE ?= 0
+endif
 
 # Build goals that get the target WP module type from the LEGATO_TARGET environment variable.
 # If LEGATO_TARGET is defined (e.g., when using leaf), then you can run 'make yellow', for example.
@@ -120,6 +125,13 @@ $(YELLOW_GOALS): yellow_%: legato_%
 		echo "* ERROR: Bosch bsec library not found at BSEC_DIR ($(BSEC_DIR))." ; \
 		echo "*        See components/boschBsec/README.md ." >&2 ; \
 		echo "*" ; \
+		false ; \
+	fi
+	@if [ "$(OCTAVE)" == "1" -a "$(OCTAVE_ROOT)" == "" ]; then \
+		echo "* ERROR: OCTAVE_ROOT not defined. Cannot build Octave support." >&2 ; \
+		echo "*        Set OCTAVE_ROOT to the directory in which the Octave .app" >&2 ; \
+		echo "*        files can be found, or set OCTAVE=0 (or unset OCTAVE) to" >&2 ; \
+		echo "*        build without Octave." >&2 ; \
 		false ; \
 	fi
 	# Build the Cypress WiFi driver.


### PR DESCRIPTION
Print a helpful error if OCTAVE=1 and OCTAVE_ROOT not set.

Default OCTAVE=0 (so build succeeds) when OCTAVE_ROOT is not set
and OCTAVE is not defined. This will minimize interruption of
work for people who don't have access to the Octave apps or
the sources needed to build them (which is most people right now).