### PR TITLE
Fix target name in .cwe file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,11 +177,10 @@ endif
 # Rule for generating legato.cwe files from .update files.
 CWE_FILES = $(foreach board,$(BOARDS),build/$(board)_$(LEGATO_TARGET)/legato.cwe)
 $(CWE_FILES): build/%_$(LEGATO_TARGET)/legato.cwe: $(UPDATE_FILE_DIR)/%.$(LEGATO_TARGET).update
-	systoimg -s $(LEGATO_TARGET) $< build/yellow_wp76xx
+	systoimg -s $(LEGATO_TARGET) $< build/yellow_$(LEGATO_TARGET)
 
 # Goals, like "yellow_spk", for building complete .spk files for factory programming.
 # The names of the resulting .spk files are of the form build/yellow_wp76xx.spk.
-# NOTE: This requires leaf.
 FACTORY_SPK_GOALS = $(foreach board,$(BOARDS),$(board)_spk)
 .PHONY: $(FACTORY_SPK_GOALS)
 $(FACTORY_SPK_GOALS): %_spk: % build/%_$(LEGATO_TARGET).spk


### PR DESCRIPTION
It was always using `wp76xx` in the .cwe file name, regardless of which target you build for.

Also, the comment about requiring leaf was not strictly correct.