### PR TITLE
bluetoothSensorTag: support CC1350 SensorTag

### DIFF
--- a/samples/BluetoothSensorTag/sensorTagComponent/sensorTag.c
+++ b/samples/BluetoothSensorTag/sensorTagComponent/sensorTag.c
@@ -137,7 +137,8 @@ static BluezDevice1 *TryCreateSensorTagDeviceProxy
     if (dev != NULL)
     {
         const gchar *deviceName = bluez_device1_get_name(dev);
-        if (g_strcmp0("CC2650 SensorTag", deviceName) != 0)
+        if (g_strcmp0("CC2650 SensorTag", deviceName) != 0 &&
+            g_strcmp0("CC1350 SensorTag", deviceName) != 0)
         {
             // Not a match, so dispose of the object
             g_clear_object(&dev);

--- a/samples/BluetoothSensorTag/toggle_leds.sh
+++ b/samples/BluetoothSensorTag/toggle_leds.sh
@@ -3,6 +3,6 @@
 while true; do
     dhub push /app/bluetoothSensorTag/io/value --json '{ "redLed": true, "greenLed": false, "buzzer": false }';
     sleep 2;
-    dhub push /app/bluetoothSensorTag/io/value --json '{ "redLed": false, "greenLed": true, "buzzer": false }';
+    dhub push /app/bluetoothSensorTag/io/value --json '{ "redLed": false, "greenLed": true, "buzzer": true }';
     sleep 2;
 done


### PR DESCRIPTION
Update to support the CC1350 SensorTag in addition to the already
supported CC2650.  The CC1350 doesn't have a green LED, so the
toggle_leds.sh script has been updated to also control the buzzer.  This
makes it easier for an observer to distinguish the red LED blinking from
the advertising pattern (also red LED blinking).