### PR TITLE
Assume empty eeprom is yellow dv3

### DIFF
--- a/linux_kernel_modules/mangoh/mangoh_yellow_dev.mdef
+++ b/linux_kernel_modules/mangoh/mangoh_yellow_dev.mdef
@@ -18,7 +18,7 @@ params:
     /*
      * Do not perform EEPROM based revision detection and assume that the revision is as specified
      */
-    force_revision = "dv3"
+    // force_revision = "dv3"
 
 
     /*


### PR DESCRIPTION
Rather than forcing to assume that the board is DV3, instead I propose that we treat all completely empty EEPROMs as DV3.

So:
 "mangOH Yellow DV3" -> DV3
Empty (all 0xff) -> DV3
No EEPROM present -> DV2
Anything else -> fail the probe of the mangoh_yellow module