### PR TITLE
Default wifiService to off and Cypress script does more

### DIFF
--- a/linux_kernel_modules/cypwifi/scripts/cywifi.sh
+++ b/linux_kernel_modules/cypwifi/scripts/cywifi.sh
@@ -54,8 +54,14 @@ cy_wifi_start() {
 		WL_REG_ON_VALUE=`cat /sys/class/gpio/gpio${WL_REG_ON_GPIO}/value`
 		if [ $WL_REG_ON_VALUE -eq 0 ] ; then
 			echo 1  > /sys/class/gpio/gpio${WL_REG_ON_GPIO}/value
+			# TODO: fix. WL_HOST_WAKE (GPIO42) should tell us that the
+			# the Cypress chip is powered on. On DV3, may not be
+			# connected. If it works the sleep below can be removed.
 			sleep 2
 			modprobe sdhci-msm
+			# TODO: fix. Remove sleep below after more testing.
+			# Thought I saw issues in the BRCM FMAC coming up to soon.
+			# Btw, brcmfmac does have reconnect to sdio code.
 			sleep 2
 		fi
 	fi

--- a/wifi.sdef
+++ b/wifi.sdef
@@ -17,7 +17,7 @@ buildVars:
 apps:
 {
     // WiFi services
-    $LEGATO_WIFI_ROOT/service/wifiService.adef
+    $LEGATO_WIFI_ROOT/service/wifiService.adef { start: manual }
     $LEGATO_WIFI_ROOT/apps/tools/wifi/wifi.adef
 }
 


### PR DESCRIPTION
Legato 19.04 DCS starts wifi immediately on startup - setting wifiService to manual makes it stop.
In meta-mangoh the Cypress chip is powered down early in the start scripts so we need to start the chip
Then load the sdhci_msm driver (unload does not work - todo: fix) and then the Cypress drivers
Note one can from the shell app start wifiService then wifi client start to startup wifi
To permanently have wifi start at boot time do config set /apps/wifiService/startManual false bool.