### PR TITLE
opt300x improvements

### DIFF
--- a/apps/YellowSensorToCloud/components/sensors/light/Component.cdef
+++ b/apps/YellowSensorToCloud/components/sensors/light/Component.cdef
@@ -31,7 +31,7 @@ requires:
     }
     file:
     {
-       /sys/bus/i2c/devices/7-0044/iio:device1/in_illuminance_input     /driver/
+       /sys/bus/i2c/devices/7-0044/iio:device1/in_intensity_input     /driver/
     }
 }
 

--- a/apps/YellowSensorToCloud/components/sensors/light/lightSensor.c
+++ b/apps/YellowSensorToCloud/components/sensors/light/lightSensor.c
@@ -18,7 +18,7 @@
 #include "lightSensor.h"
 #include "fileUtils.h"
 
-static const char LightFile[]  = "/driver/in_illuminance_input";
+static const char LightFile[]  = "/driver/in_intensity_input";
 
 
 //--------------------------------------------------------------------------------------------------
@@ -74,5 +74,5 @@ static void SampleLight
 
 COMPONENT_INIT
 {
-    (void)psensor_Create("", DHUBIO_DATA_TYPE_NUMERIC, "lux", SampleLight, NULL);
+    (void)psensor_Create("", DHUBIO_DATA_TYPE_NUMERIC, "nW/cm2", SampleLight, NULL);
 }

--- a/apps/YellowSensorToCloud/components/sensors/light/lightSensor.c
+++ b/apps/YellowSensorToCloud/components/sensors/light/lightSensor.c
@@ -31,7 +31,7 @@ static const char LightFile[]  = "/driver/in_intensity_input";
 le_result_t light_Read
 (
     double* readingPtr
-        ///< [OUT] Where the reading (in LUX) will be put if LE_OK is returned.
+        ///< [OUT] Where the reading (in W/m2) will be put if LE_OK is returned.
 )
 {
     double light;
@@ -40,7 +40,10 @@ le_result_t light_Read
     {
         return r;
     }
-    *readingPtr = ((double)light);
+
+    const double cmSquaredPerMeterSquared = 100.0 * 100.0;
+    const double nanoWattsPerWatt = 1000000000.0;
+    *readingPtr = light * (cmSquaredPerMeterSquared / nanoWattsPerWatt);
 
     return LE_OK;
 }
@@ -74,5 +77,5 @@ static void SampleLight
 
 COMPONENT_INIT
 {
-    (void)psensor_Create("", DHUBIO_DATA_TYPE_NUMERIC, "nW/cm2", SampleLight, NULL);
+    (void)psensor_Create("", DHUBIO_DATA_TYPE_NUMERIC, "W/m2", SampleLight, NULL);
 }

--- a/linux_kernel_modules/opt300x/opt300x.c
+++ b/linux_kernel_modules/opt300x/opt300x.c
@@ -734,6 +734,8 @@ static irqreturn_t opt300x_irq(int irq, void *_iio)
 	struct iio_dev *iio = _iio;
 	struct opt300x *opt = iio_priv(iio);
 	int ret;
+	bool wake_result_ready_queue = false;
+
 
 	if (!opt->ok_to_ignore_lock)
 		mutex_lock(&opt->lock);
@@ -768,12 +770,15 @@ static irqreturn_t opt300x_irq(int irq, void *_iio)
 		}
 		opt->result = ret;
 		opt->result_ready = true;
-		wake_up(&opt->result_ready_queue);
+		wake_result_ready_queue = true;
 	}
 
 out:
 	if (!opt->ok_to_ignore_lock)
 		mutex_unlock(&opt->lock);
+
+	if (wake_result_ready_queue)
+		wake_up(&opt->result_ready_queue);
 
 	return IRQ_HANDLED;
 }

--- a/linux_kernel_modules/opt300x/opt300x.c
+++ b/linux_kernel_modules/opt300x/opt300x.c
@@ -149,7 +149,7 @@ static const struct opt300x_scale opt3002_scales[] = {
 	},
 	{
 		.val = 19656,
-		.val2 =0,
+		.val2 = 0,
 	},
 	{
 		.val = 39312,
@@ -219,7 +219,7 @@ static const struct opt300x_chip opt3002_chip = {
 struct opt300x {
 	struct i2c_client	*client;
 	struct device		*dev;
-        
+
  	struct opt300x_chip     *chip;
 	struct mutex		lock;
 	bool			ok_to_ignore_lock;
@@ -269,7 +269,7 @@ static void opt300x_to_iio_ret(struct opt300x *opt, u8 exponent,
 	u64 lux;
 	u64 tmp;
         u16  multiplier1 = opt->chip->multiplier_numerator;
-        u16  multiplier2 = opt->chip->multiplier_denominator; 
+        u16  multiplier2 = opt->chip->multiplier_denominator;
 	tmp = 1000000ull;
 	do_div(tmp, multiplier2);
 	lux = tmp * (mantissa << exponent) * multiplier1;
@@ -726,7 +726,7 @@ static int opt300x_read_id(struct opt300x *opt)
 			return ret;
 		}
 		device_id = ret;
-		
+
 		if (device_id != opt->chip->device_id) {
 			//dev_err("opt->dev, Invalid Device id %d", device_id);
 			return -ENODEV;

--- a/linux_kernel_modules/opt300x/opt300x.c
+++ b/linux_kernel_modules/opt300x/opt300x.c
@@ -81,139 +81,55 @@
 
 
 struct opt300x_scale {
-	int	val;
-	int	val2;
+	int val;
+	int val2;
 };
-
-static const struct opt300x_scale opt3001_scales[] = {
-	{
-		.val = 40,
-		.val2 = 950000,
-	},
-	{
-		.val = 81,
-		.val2 = 900000,
-	},
-	{
-		.val = 163,
-		.val2 = 800000,
-	},
-	{
-		.val = 327,
-		.val2 = 600000,
-	},
-	{
-		.val = 655,
-		.val2 = 200000,
-	},
-	{
-		.val = 1310,
-		.val2 = 400000,
-	},
-	{
-		.val = 2620,
-		.val2 = 800000,
-	},
-	{
-		.val = 5241,
-		.val2 = 600000,
-	},
-	{
-		.val = 10483,
-		.val2 = 200000,
-	},
-	{
-		.val = 20966,
-		.val2 = 400000,
-	},
-
-        {
-		.val = 41932,
-		.val2 = 800000,
-	},
-
-	{
-		.val = 83865,
-		.val2 = 600000,
-	},
-};
-
-static const struct opt300x_scale opt3002_scales[] = {
-	{
-		.val =  4914,
-		.val2 = 0,
-	},
-	{
-		.val =  9828,
-		.val2 = 0,
-	},
-	{
-		.val = 19656,
-		.val2 = 0,
-	},
-	{
-		.val = 39312,
-		.val2 = 0,
-	},
-	{
-		.val = 78624,
-		.val2 = 0,
-	},
-	{
-		.val = 157248,
-		.val2 = 0,
-	},
-	{
-		.val = 314496,
-		.val2 = 0,
-	},
-	{
-		.val = 628992,
-		.val2 = 0,
-	},
-	{
-		.val = 1257984,
-		.val2 = 0,
-	},
-	{
-		.val = 2515968,
-		.val2 = 0,
-	},
-	{
-		.val = 5031936,
-		.val2 = 0,
-	},
-
-	{
-		.val = 10063872,
-		.val2 = 0,
-	},
-};
-
-
 
 struct opt300x_chip {
 	int device_id;
 	u8 scaler_numerator;
 	u8 scaler_denominator;
-        const struct opt300x_scale *table;
-	size_t table_num_entries;
+        const struct opt300x_scale table[12];
 };
 
 static const struct opt300x_chip opt3001_chip = {
 	.device_id = OPT3001_DEVICE_ID,
 	.scaler_numerator = 1,
 	.scaler_denominator = 100,
-	.table = opt3001_scales,
-	.table_num_entries = ARRAY_SIZE(opt3001_scales),
+	.table = {
+		{ .val =    40, .val2 = 950000, },
+		{ .val =    81, .val2 = 900000, },
+		{ .val =   163, .val2 = 800000, },
+		{ .val =   327, .val2 = 600000, },
+		{ .val =   655, .val2 = 200000, },
+		{ .val =  1310, .val2 = 400000, },
+		{ .val =  2620, .val2 = 800000, },
+		{ .val =  5241, .val2 = 600000, },
+		{ .val = 10483, .val2 = 200000, },
+		{ .val = 20966, .val2 = 400000, },
+		{ .val = 41932, .val2 = 800000, },
+		{ .val = 83865, .val2 = 600000, },
+	},
 };
 
 static const struct opt300x_chip opt3002_chip = {
 	.device_id = -1,
 	.scaler_numerator = 6,
 	.scaler_denominator = 5,
-	.table = opt3002_scales,
-	.table_num_entries = ARRAY_SIZE(opt3002_scales),
+	.table = {
+		{ .val =     4914, .val2 = 0, },
+		{ .val =     9828, .val2 = 0, },
+		{ .val =    19656, .val2 = 0, },
+		{ .val =    39312, .val2 = 0, },
+		{ .val =    78624, .val2 = 0, },
+		{ .val =   157248, .val2 = 0, },
+		{ .val =   314496, .val2 = 0, },
+		{ .val =   628992, .val2 = 0, },
+		{ .val =  1257984, .val2 = 0, },
+		{ .val =  2515968, .val2 = 0, },
+		{ .val =  5031936, .val2 = 0, },
+		{ .val = 10063872, .val2 = 0, },
+	},
 };
 
 struct opt300x {
@@ -245,14 +161,13 @@ static int opt300x_find_scale(const struct opt300x *opt, int val,
 	int i;
         int val_tmp = (val * 1000ll +  val2 / 1000);
 
-	for (i = 0; i < opt->chip->table_num_entries; i++) {
+	for (i = 0; i < ARRAY_SIZE(opt->chip->table); i++) {
 		const struct opt300x_scale *scale = &opt->chip->table[i];
 
 		int scale_tmp = (scale->val * 1000ll + scale->val2 / 1000);
 		/*
-		 * Combine the integer and micro parts for comparison
-		 * purposes. Use milli lux precision to avoid 32-bit integer
-		 * overflows.
+		 * Combine the whole and micro parts for comparison purposes.
+		 * Use milli precision to avoid 32-bit integer overflows.
 		 */
 		if (val_tmp <= scale_tmp) {
 			*exponent = i;

--- a/linux_kernel_modules/opt300x/opt300x.c
+++ b/linux_kernel_modules/opt300x/opt300x.c
@@ -89,7 +89,7 @@ struct opt300x_chip {
 	int device_id;
 	u8 scaler_numerator;
 	u8 scaler_denominator;
-        const struct opt300x_scale table[12];
+	const struct opt300x_scale table[12];
 };
 
 static const struct opt300x_chip opt3001_chip = {
@@ -136,7 +136,7 @@ struct opt300x {
 	struct i2c_client	*client;
 	struct device		*dev;
 
- 	struct opt300x_chip     *chip;
+	struct opt300x_chip	*chip;
 	struct mutex		lock;
 	bool			ok_to_ignore_lock;
 	bool			result_ready;
@@ -159,7 +159,7 @@ static int opt300x_find_scale(const struct opt300x *opt, int val,
 		int val2, u8 *exponent)
 {
 	int i;
-        int val_tmp = (val * 1000ll +  val2 / 1000);
+	int val_tmp = (val * 1000ll + val2 / 1000);
 
 	for (i = 0; i < ARRAY_SIZE(opt->chip->table); i++) {
 		const struct opt300x_scale *scale = &opt->chip->table[i];
@@ -183,8 +183,8 @@ static void opt300x_to_iio_ret(struct opt300x *opt, u8 exponent,
 {
 	u64 res;
 	u64 tmp;
-        u8 numerator = opt->chip->scaler_numerator;
-        u8 denominator = opt->chip->scaler_denominator;
+	u8 numerator = opt->chip->scaler_numerator;
+	u8 denominator = opt->chip->scaler_denominator;
 	tmp = 1000000ull;
 	do_div(tmp, denominator);
 	res = tmp * (mantissa << exponent) * numerator;
@@ -498,10 +498,10 @@ static int opt300x_write_event_value(struct iio_dev *iio,
 	u16 reg;
 
 	u8 exponent;
-        u64 tmp;
+	u64 tmp;
 
-        u8 numerator = opt->chip->scaler_numerator;
-        u8 denominator = opt->chip->scaler_denominator;
+	u8 numerator = opt->chip->scaler_numerator;
+	u8 denominator = opt->chip->scaler_denominator;
 
 
 	if (val < 0)
@@ -515,9 +515,9 @@ static int opt300x_write_event_value(struct iio_dev *iio,
 		goto err;
 	}
 
-        tmp  = ((val * 1000000ull) + val2) * denominator;
-        do_div(tmp, numerator * 1000000ull);
-        mantissa = tmp >> exponent;
+	tmp = ((val * 1000000ull) + val2) * denominator;
+	do_div(tmp, numerator * 1000000ull);
+	mantissa = tmp >> exponent;
 
 	value = (exponent << 12) | mantissa;
 
@@ -631,7 +631,7 @@ static int opt300x_read_id(struct opt300x *opt)
 				manufacturer);
 		return -ENODEV;
 	}
-        dev_info(opt->dev, "manufacturer id (%u)\n",manufacturer);
+	dev_info(opt->dev, "manufacturer id (%u)\n",manufacturer);
 
 	if (opt->chip->device_id >= 0) {
 		ret = i2c_smbus_read_word_swapped(opt->client, OPT3001_DEVICE_ID);
@@ -768,7 +768,7 @@ static int opt300x_probe(struct i2c_client *client,
 		const struct i2c_device_id *id)
 {
 	struct device *dev = &client->dev;
-        struct opt300x_chip *c = (struct opt300x_chip *)id->driver_data;
+	struct opt300x_chip *c = (struct opt300x_chip *)id->driver_data;
 	struct iio_dev *iio;
 	struct opt300x *opt;
 	int ret;
@@ -782,7 +782,7 @@ static int opt300x_probe(struct i2c_client *client,
 	opt = iio_priv(iio);
 	opt->client = client;
 	opt->dev = dev;
-        opt->chip = c;
+	opt->chip = c;
 	mutex_init(&opt->lock);
 	init_waitqueue_head(&opt->result_ready_queue);
 	i2c_set_clientdata(client, iio);
@@ -862,7 +862,7 @@ static int opt300x_remove(struct i2c_client *client)
 static const struct i2c_device_id opt300x_id[] = {
 	{ "opt3001", (kernel_ulong_t)&opt3001_chip },
 	{ "opt3002", (kernel_ulong_t)&opt3002_chip },
-        { } /* Terminating Entry */
+	{ } /* Terminating Entry */
 };
 MODULE_DEVICE_TABLE(i2c, opt300x_id);
 


### PR DESCRIPTION
better differentiate between the opt3001 and the opt3002 (used in mangOH Yellow).  After this set of changes, we no longer falsely claim to be reporting lux.