### PR TITLE
Updated docs - README mostly.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,6 @@
 [submodule "apps/DataHub"]
 	path = apps/DataHub
 	url = https://github.com/mangOH/legatoDataHub
+[submodule "experimental/waveshare_eink/apps/EinkDhubIf"]
+	path = experimental/waveshare_eink/apps/EinkDhubIf
+	url = https://github.com/mangOH/EinkDhub

--- a/experimental/waveshare_eink/linux_kernel_modules/README.md
+++ b/experimental/waveshare_eink/linux_kernel_modules/README.md
@@ -1,87 +1,27 @@
 # mangOH Waveshare E-Ink Linux Framebuffer driver
 
-For integration mangOH Red and Waveshare E-Ink Display
+mangOH Red/Yellow (note separate drivers exist for Red & Yellow) drivers for the Waveshare 2.13 E-Ink Display
+Code is experimental so far and the instructions below are tailored to the Yellow and WP7[67]xx. TODO, fix for Red.
+Note, original code-base was for WP85 on Red, so should be able to adapt.
 
-### 1. Download Legato Distribution Source Package from sierra wireless website:
-    Yocto Source (Around 4 GB)
-    The file name is Legato-Dist-Source-mdm9x15-SWI9X15Y_07.13.05.00.tar.bz2
+### 1. Dependency on meta-mangOH for FB core & helper drivers - standard mangOH spk should have already.
 
-### 2. Extract the downloaded Distribution source package:
+### 2. Need to include sinc/waveshare_eink.sinc in the yellow.sdef and build it.
 
-    Run command: tar -xvjf Legato-Dist-Source-mdm9x15-SWI9X15Y_07.13.05.00.tar.bz2
+    Note for Legato 19.04 please add the waveshare_eink.sinc to the end of the file as
+    mksys crashes in the build if it is added in the beginning of the yellow.sdef.
 
-### 3. Disable Legato configuration to build Yocto
+### 3. Tested on Legato 19.04 with these shell startup/stop scripts
 
-    Run command: cd yocto
-    Run command: export LEGATO_BUILD=0
+    scp(1) scripts/start_eink.sh/stop_eink.sh to the target.
+    Need to run the start_eink.sh after bootup from a shell to load the kernel loadable
+    modules, mangOH_yellow_ws213, fb_waveshare_eink, and finally EinkDhubIf app in that order.
+    To remove just run stop_eink.sh and then app stop EinkDhubIf in that order.
 
-### 4. Build Yocto images from source
+### 4. Currently is ready for auto-startup on Legato 19.07 as it allows mdef start/stop scripts.
 
-    Run command: make image_bin
-    If you get the error not found 'serf.h', then follow the steps below, otherwise skip to the next step.
-        Go to directory: cd meta-swi/common/recipes-devtools/
-        create directory: mkdir subversion
-        Put attach file: subversion_1.8.9.bbappend, under directory subversion
-        The full path would be: yocto/meta-swi/common/recipes-devtools/subversion/subversion_1.8.9.bbappend
-        build Yocto images again: make image_bin
-### 5. Set environment under yocto directory, this will get command bitbake run:
+    Note, kludges are noted in the mangOH_yellow_ws213 start script in regards
+    to the SPI busy port and other issues. mangOH_yellow_ws213 needs to deal with the
+    SPI bus renumbering off of the sx1509q.
 
-    Run Command: . ./poky/oe-init-build-env
-    
-### 6. Build Linux kernel with Buffer Frame driver modules support
-
-    Go to directory: yocto/build_bin (cd …/build_bin)
-    Configure kernel with default:
-        Run command: bitbake linux-yocto -c kernel_configme -f
-    Configure kernel to add BT driver module in Linux configuration
-        Run command: bitbake linux-yocto -c menuconfig
-        Enter Device Driver -> Graphic Support
-        Enter <M> Suport for frameBuffer devices
-            <M> Ion Memory Manager
-            <> Lowlevel video output switch controls
-            <*> Support for frame buffer devices 
-                 [*] Enable firmware EDID
-                 [*] Framebuffer foreign endianess support --->
-                 -*- Enable Video Mode Hangling Helper
-                 [*] Enable Tile Blitting Support
-                     ***Frame buffer hardware drivers***
-                 <M> OpenCores VGA/LCD core 2.0 framebuffer support
-                 <M> Epson S1D13XXX framebuffer support
-                 <M> Toshiba Mobile IO framebuffer support
-                 [*] tmiofb acceleration (NEW)
-                 <M> SMSC UFX6000/7000 USB Framebuffer support
-                 <M> Displaylink USB Framebuffer support
-                 <M> Goldfish Framebuffer 
-                 <M> Vitrual Frame Buffer support(ONLY FOR TESTING)
-                 <M> E-Ink Metronome/8track controller support
-                 <M> MSM Framebuffer support
-                 <M> E-Ink Broadsheet/Epson S1D13521 controller support
-                 <M> AUO-K190X EPD controller support
-                    <M> AUO-K1900 EPD controller support
-                    <M> AUO-K190X\1 EPD controller support
-                 [*] Simple framebuffer support 
-        [*] Esynos Video driver support 
-            Console display driver support 
-            <*> Framebuffer Console support
-            [*]     Map the console to primary display device
-            [*]     Framebuffer Console Rotation
-    Exit and save Frame Buffer Linux config
-    Rebuild kernel image: bitbake -f linux-yocto
- 
- ### 7. Rebuild rootfs filesystem and images
-    
-    bitbake -c cleansstate mdm9x15-image-minimal
-    bitbake mdm9x15-image-minimal
-
-Check new build CWE images: yocto_wp85.cwe
-
-    Go to images directory: cd build_bin/tmp/deploy/images/swi-mdm9x15
-
-Reflash new image with Frame Buffer driver module support to the target board
-
-    on Windows: FDT command: fdt yocto_wp85.cwe 
-    on Linux: by command: fwupdate download yocto_wp85.cwe
-
-
-
-
+### 6. Please see TODO.md for more things to fix.

--- a/experimental/waveshare_eink/linux_kernel_modules/TODO.md
+++ b/experimental/waveshare_eink/linux_kernel_modules/TODO.md
@@ -62,7 +62,5 @@ that we think we are and that the device is functional.
 
 
 ## Challenges
-How should we deal with the fact that this driver depends on features of the kernel that aren't
-explicitly selectable using menuconfig? I doubt the system reference team would be happy about us
-enabling config for a bunch of device drivers for devices that we don't intend to use so that the
-side-effect of getting `sys_imageblit()` (for example) included into the kernel is achieved.
+Driver needs to gate writes into the display - currently, we have put waits into the app.
+Correctly, the driver should do handshaking to see when writes are okay to proceed.

--- a/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
+++ b/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.c
@@ -346,16 +346,18 @@ static int ws_eink_update_display(struct ws_eink_fb_par *par)
 	u8 *ssbuf = par->ssbuf;
 	const u8 *lut;
 	size_t lut_size;
-	static int update_count = 0;
 
-	if(++update_count == 10) {
-		update_count = 0;
-		lut = lut_full_update;
-		lut_size = ARRAY_SIZE(lut_full_update);
-	} else {
-		lut = lut_partial_update;
-		lut_size = ARRAY_SIZE(lut_partial_update);
-	}
+        /* Previous code had partial refresh for a count of 10 here.
+         * Removed because serious ghosting issues existed. On further
+         * investigation found from
+         *    https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT
+         * that these ghosting issues may even damage the display.
+         * Thus, we only do full refresh for now - TODO: see
+         * if a better combination of partial/full exists.
+         */
+
+	lut = lut_full_update;
+	lut_size = ARRAY_SIZE(lut_full_update);
 
 	ret = int_lut(par, lut, lut_size);
 	if (ret)

--- a/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.mdef
+++ b/experimental/waveshare_eink/linux_kernel_modules/fb_waveshare_eink.mdef
@@ -3,13 +3,16 @@ sources:
     fb_waveshare_eink.c
 }
 
-cflags:
+requires:
 {
-    // -DDEBUG
+	kernelModules:
+	{
+		$CURDIR/mangOH_yellow_ws213
+	}
 }
 
-params:
-{
-}
-
+// mangOH_yellow_ws213.mdef install script first loads loadable kernel modules, then
+// mangOH_yellow_ws213 and then this module in that order - Legato does not handle
+// dependencies on loadable kernel modules and we also have to kludge over Linux/hardware
+// issues with the SPI busy port.
 load: manual

--- a/experimental/waveshare_eink/linux_kernel_modules/mangOH_yellow_ws213.mdef
+++ b/experimental/waveshare_eink/linux_kernel_modules/mangOH_yellow_ws213.mdef
@@ -9,8 +9,24 @@ cflags:
     -DCONFIG_RPIFB
 }
 
-params:
+requires:
 {
+    kernelModules:
+    {
+	// This dependency is needed as the gpiochip ports are not
+	// ready for this module unless the yellow driver sets them
+	// up properly.
+        $CURDIR/../../../linux_kernel_modules/mangoh/mangoh_yellow_dev
+    }
 }
 
-load: manual
+
+// Note the start script has had kludge over many issues.
+scripts:
+{
+    install:  $CURDIR/scripts/start_waveshare.sh
+    remove:   $CURDIR/scripts/stop_waveshare.sh
+}
+
+load: auto
+

--- a/experimental/waveshare_eink/linux_kernel_modules/scripts/start_waveshare.sh
+++ b/experimental/waveshare_eink/linux_kernel_modules/scripts/start_waveshare.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Eink kernel module installer - lets load any core FB loadable modules
+# If the no core loadable modules exist you have a bogus kernel with no video
+# helper routines.
+# The sleep's below exist because we are superstitious.
+
+# At times with Legato 19.07 & the associated SWI Linux/rootfs
+# the SPI busy port has not been created when the mangOH config
+# module is loaded. 
+
+# Make 10 attempts to check whether SPI busy port for Eink exists
+# Sleep 1s in between
+for i in $(seq 1 10)
+do
+  if [ -d /sys/devices/78b8000.i2c/i2c-4/i2c-8/8-003e ] ; then
+    break
+  fi
+  sleep 1
+done
+
+# return error if device file hasn't been created after 10 secs
+if [ "$i" -eq "10" ] ; then
+  echo "SPI busy existence via the sx1509q gpiochip failed" > /dev/console
+  exit 1
+fi
+
+
+VERSION=`uname -r`
+
+# Most displays will need at least some of the video/graphics helper routines.
+if [ ! -d "/lib/modules/${VERSION}/kernel/drivers/video/fbdev/core" ] ; then
+	echo "Kernel does not support video helper routines" > /dev/console
+	exit 1
+fi
+
+for i in /lib/modules/${VERSION}/kernel/drivers/video/fbdev/core/*.ko ; do
+	modprobe `basename $i .ko`
+	if [ $? -ne 0 ] ; then
+		echo "modprobe `basename $i .ko` failed" > /dev/console
+		exit 1
+	fi
+done
+sleep 1
+
+# Let's load the Legato built kernel modules
+insmod /legato/systems/current/modules/mangOH_yellow_ws213.ko
+if [ $? -ne 0 ] ; then
+	echo "insmod mangOH_yellow_ws213 failed" > /dev/console
+	exit 1
+fi
+sleep 1
+
+insmod /legato/systems/current/modules/fb_waveshare_eink.ko
+if [ $? -ne 0 ] ; then
+	echo "insmod fb_waveshare_eink failed" > /dev/console
+	exit 1
+fi
+sleep 1
+
+exit 0

--- a/experimental/waveshare_eink/linux_kernel_modules/scripts/stop_waveshare.sh
+++ b/experimental/waveshare_eink/linux_kernel_modules/scripts/stop_waveshare.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# The sleep's are below beacuse I am superstitious.
+
+# Note any apps that have connected to /dev/fb need to exit
+# before fb_waveshare_eink is removed - assumption is that
+# Legato 19.07 removes all apps before modules. Note in
+# Legato 19.07 any app dependencies on modules are removed
+# in the wrong order - Jira ticket LE-13549 - add back
+# proper dependencies in the apps once the ticket is fixed.
+rmmod /legato/systems/current/modules/fb_waveshare_eink.ko
+if [ $? -ne 0 ] ; then
+	echo "rmmod fb_waveshare_eink failed" > /dev/console
+	exit 1
+fi
+sleep 1
+
+rmmod /legato/systems/current/modules/mangOH_yellow_ws213.ko
+if [ $? -ne 0 ] ; then
+	echo "rmmod mangOH_yellow_ws213 failed" > /dev/console
+	exit 1
+fi
+sleep 1
+
+VERSION=`uname -r`
+for i in /lib/modules/${VERSION}/kernel/drivers/video/fbdev/core/*.ko ; do
+	modprobe -r `basename $i .ko`
+	if [ $? -ne 0 ] ; then
+		echo "modprobe -r `basename $i .ko` failed" > /dev/console
+		exit 1
+	fi
+done

--- a/experimental/waveshare_eink/waveshare_eink.sinc
+++ b/experimental/waveshare_eink/waveshare_eink.sinc
@@ -1,0 +1,40 @@
+/*
+ * Experimental - waveshare kernel modules for mangOH Yellow and a Eink dhub app that
+ *                writes data from the dhub to the waveshare Eink display.
+ *
+ * Directions: Include this file in the yellow.sdef file.
+ *
+ * Dependencies: assumes mangOH Yellow kernel was built from meta-mangOH repo which
+ *               by default includes the core Framebuffer (FB) & FB  helpers as loaadable
+ *               modules. The kernel module install remove scripts had issues with Legato 19.07
+ *               thus tested only on Legato 19.04 which does not allow install remove scripts.
+ *               TODO: fix for 19.07.
+ *               
+ *               Includes the littlevgl graphics library embedded with the app.
+ *
+ *               On Legato 19.04 if one includes this file in the beginning
+ *               of yellow.sdef mksys segfaults - at the end it works.
+ */
+
+apps:
+{
+#if ${MANGOH_BOARD} = yellow
+    $CURDIR/apps/EinkDhubIf/EinkDhubIf
+#endif
+}
+
+bindings:
+{
+#if ${MANGOH_BOARD} = yellow
+    EinkDhubIf.dhubIO -> dataHub.io
+#endif
+}
+
+kernelModules:
+{
+#if ${MANGOH_BOARD} = yellow
+    $CURDIR/linux_kernel_modules/mangOH_yellow_ws213
+    $CURDIR/linux_kernel_modules/fb_waveshare_eink
+#endif
+}
+


### PR DESCRIPTION
Changed fb_waveshare_eink to use full refresh rather than partial (for ghosting) & to save the display.
Added a sinc file to to include Eink apps & the modules as needed in yellow.sdef.
Auto loading of mangOH_yellow_ws213 and install scripts based on it that loads loadable modules and fb_waveshare module in order.
Legato 19.07 & latest SWI firmware seems to renumber SPI 2nd bus on every Legato stop/start, update, ... - work around.
sx1509q SPI busy also has issue on startup in Legato ordering of things - workaround in install script and error check in mangOH_yellow_ws213.