### PR TITLE
shared.sdef: remove periodicSensor from interfaceSearch

### DIFF
--- a/shared.sdef
+++ b/shared.sdef
@@ -35,7 +35,6 @@ interfaceSearch:
     $CURDIR/interfaces
     $CURDIR/apps/LedService
     $CURDIR/apps/DataHub
-    $CURDIR/apps/DataHub/components/periodicSensor
 }
 
 componentSearch:


### PR DESCRIPTION
periodicSensor provides no .api files and the "provies/headerDir"
definition in the component provides a suitable discovery mechanism for
clients to get access to the .h file.