### PR TITLE
Fix warning about missing ']'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ $(YELLOW_GOALS): yellow_%: legato_%
 		echo "*" ; \
 		false ; \
 	fi
-	@if [ "$(OCTAVE)" = "1" && "$(OCTAVE_ROOT)" = "" ]; then \
+	@if [ "$(OCTAVE)" = "1" -a "$(OCTAVE_ROOT)" = "" ]; then \
 		echo "* ERROR: OCTAVE_ROOT not defined. Cannot build Octave support." >&2 ; \
 		echo "*        Set OCTAVE_ROOT to the directory in which the Octave .app" >&2 ; \
 		echo "*        files can be found, or set OCTAVE=0 (or unset OCTAVE) to" >&2 ; \


### PR DESCRIPTION
This branch fixes an error displayed when you run make:
/bin/sh: line 0: [: missing `]'
The culprit is the use of "&&" inside of an if [ ] block.