### PR TITLE
Fix "random" panic in bq27xxx driver when unloaded

### DIFF
--- a/linux_kernel_modules/bq27xxx/bq27xxx_battery_source.c
+++ b/linux_kernel_modules/bq27xxx/bq27xxx_battery_source.c
@@ -1601,48 +1601,51 @@ void bq27xxx_battery_update(struct bq27xxx_device_info *di)
 	bool has_ci_flag = di->opts & BQ27XXX_O_ZERO;
 	bool has_singe_flag = di->opts & BQ27XXX_O_ZERO;
 
-	cache.flags = bq27xxx_read(di, BQ27XXX_REG_FLAGS, has_singe_flag);
-	if ((cache.flags & 0xff) == 0xff)
-		cache.flags = -1; /* read error */
-	if (cache.flags >= 0) {
-		cache.temperature = bq27xxx_battery_read_temperature(di);
-		if (has_ci_flag && (cache.flags & BQ27000_FLAG_CI)) {
-			dev_info(di->dev, "battery is not calibrated! ignoring capacity values\n");
-			cache.capacity = -ENODATA;
-			cache.energy = -ENODATA;
-			cache.time_to_empty = -ENODATA;
-			cache.time_to_empty_avg = -ENODATA;
-			cache.time_to_full = -ENODATA;
-			cache.charge_full = -ENODATA;
-			cache.health = -ENODATA;
-		} else {
-			if (di->regs[BQ27XXX_REG_TTE] != INVALID_REG_ADDR)
-				cache.time_to_empty = bq27xxx_battery_read_time(di, BQ27XXX_REG_TTE);
-			if (di->regs[BQ27XXX_REG_TTECP] != INVALID_REG_ADDR)
-				cache.time_to_empty_avg = bq27xxx_battery_read_time(di, BQ27XXX_REG_TTECP);
-			if (di->regs[BQ27XXX_REG_TTF] != INVALID_REG_ADDR)
-				cache.time_to_full = bq27xxx_battery_read_time(di, BQ27XXX_REG_TTF);
-			cache.charge_full = bq27xxx_battery_read_fcc(di);
-			cache.capacity = bq27xxx_battery_read_soc(di);
-			if (di->regs[BQ27XXX_REG_AE] != INVALID_REG_ADDR)
-				cache.energy = bq27xxx_battery_read_energy(di);
-			cache.health = bq27xxx_battery_read_health(di);
+	/* inhibit updates while tearing down */
+	if (poll_interval > 0) {
+		cache.flags = bq27xxx_read(di, BQ27XXX_REG_FLAGS, has_singe_flag);
+		if ((cache.flags & 0xff) == 0xff)
+			cache.flags = -1; /* read error */
+		if (cache.flags >= 0) {
+			cache.temperature = bq27xxx_battery_read_temperature(di);
+			if (has_ci_flag && (cache.flags & BQ27000_FLAG_CI)) {
+				dev_info(di->dev, "battery is not calibrated! ignoring capacity values\n");
+				cache.capacity = -ENODATA;
+				cache.energy = -ENODATA;
+				cache.time_to_empty = -ENODATA;
+				cache.time_to_empty_avg = -ENODATA;
+				cache.time_to_full = -ENODATA;
+				cache.charge_full = -ENODATA;
+				cache.health = -ENODATA;
+			} else {
+				if (di->regs[BQ27XXX_REG_TTE] != INVALID_REG_ADDR)
+					cache.time_to_empty = bq27xxx_battery_read_time(di, BQ27XXX_REG_TTE);
+				if (di->regs[BQ27XXX_REG_TTECP] != INVALID_REG_ADDR)
+					cache.time_to_empty_avg = bq27xxx_battery_read_time(di, BQ27XXX_REG_TTECP);
+				if (di->regs[BQ27XXX_REG_TTF] != INVALID_REG_ADDR)
+					cache.time_to_full = bq27xxx_battery_read_time(di, BQ27XXX_REG_TTF);
+				cache.charge_full = bq27xxx_battery_read_fcc(di);
+				cache.capacity = bq27xxx_battery_read_soc(di);
+				if (di->regs[BQ27XXX_REG_AE] != INVALID_REG_ADDR)
+					cache.energy = bq27xxx_battery_read_energy(di);
+				cache.health = bq27xxx_battery_read_health(di);
+			}
+			if (di->regs[BQ27XXX_REG_CYCT] != INVALID_REG_ADDR)
+				cache.cycle_count = bq27xxx_battery_read_cyct(di);
+			if (di->regs[BQ27XXX_REG_AP] != INVALID_REG_ADDR)
+				cache.power_avg = bq27xxx_battery_read_pwr_avg(di);
+
+			/* We only have to read charge design full once */
+			if (di->charge_design_full <= 0)
+				di->charge_design_full = bq27xxx_battery_read_dcap(di);
 		}
-		if (di->regs[BQ27XXX_REG_CYCT] != INVALID_REG_ADDR)
-			cache.cycle_count = bq27xxx_battery_read_cyct(di);
-		if (di->regs[BQ27XXX_REG_AP] != INVALID_REG_ADDR)
-			cache.power_avg = bq27xxx_battery_read_pwr_avg(di);
 
-		/* We only have to read charge design full once */
-		if (di->charge_design_full <= 0)
-			di->charge_design_full = bq27xxx_battery_read_dcap(di);
+		if (di->cache.capacity != cache.capacity)
+			power_supply_changed(&di->bat);
+
+		if (memcmp(&di->cache, &cache, sizeof(cache)) != 0)
+			di->cache = cache;
 	}
-
-	if (di->cache.capacity != cache.capacity)
-		power_supply_changed(&di->bat);
-
-	if (memcmp(&di->cache, &cache, sizeof(cache)) != 0)
-		di->cache = cache;
 
 	di->last_update = jiffies;
 }


### PR DESCRIPTION
I observed what appeared to be random kernel panics when shutting down or rebooting a mangOH Yellow with a LiPo battery attached. They didn't happen every time. The panic starts with a warning about an attempt to lock an invalid mutex in bq27xxx_battery_get_property: DEBUG_LOCKS_WARN_ON(l->magic != l)

Further tracing indicated that a final call to bq27xxx_battery_update occurs indirectly inside of bq27xxx_battery_teardown. If the battery capacity percentage read during this update differs from what we previously thought the capacity was, power_supply_changed is called.

This was causing a final power supply uevent to be scheduled after the driver was already torn down, leading to the invalid mutex lock attempt and subsequent kernel panic when further invalid operations were attempted.

This patch works around the issue by inhibiting the final update when the bq27xxx driver is being torn down.

The diff is pretty nasty-looking on GitHub, but all the change does is wrap most of the logic in bq27xxx_battery_update with a check for whether poll_interval is 0.